### PR TITLE
Add post surveys endpoint

### DIFF
--- a/lib/feedback_api/group.ex
+++ b/lib/feedback_api/group.ex
@@ -3,6 +3,7 @@ defmodule FeedbackApi.Group do
   import Ecto.Changeset
 
   schema "groups" do
+    field :name, :string
     belongs_to :survey, FeedbackApi.Survey
     many_to_many :users, FeedbackApi.User, join_through: FeedbackApi.GroupMember
 
@@ -12,7 +13,7 @@ defmodule FeedbackApi.Group do
   @doc false
   def changeset(group, attrs) do
     group
-    |> cast(attrs, [])
-    |> validate_required([])
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
   end
 end

--- a/lib/feedback_api_web/controllers/surveys_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys_controller.ex
@@ -9,6 +9,7 @@ defmodule FeedbackApiWeb.SurveysController do
   end
 
   def create(conn, params) do
+    require IEx; IEx.pry()
     survey = Survey.changeset(%Survey{}, params)
 
     case Repo.insert(survey) do

--- a/lib/feedback_api_web/controllers/surveys_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys_controller.ex
@@ -12,7 +12,7 @@ defmodule FeedbackApiWeb.SurveysController do
   def create(conn, params) do
     case SurveyCreateFacade.create_survey(params) do
       {:ok, _survey} -> conn |> put_status(:created) |> json(%{success: "Survey stored"})
-      {:error, survey} -> conn |> put_status(:unprocessable_entity) |> json(survey.errors)
+      {:error, error} -> conn |> put_status(:unprocessable_entity) |> json(%{error: error})
     end
   end
 end

--- a/lib/feedback_api_web/controllers/surveys_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys_controller.ex
@@ -1,6 +1,7 @@
 defmodule FeedbackApiWeb.SurveysController do
   use FeedbackApiWeb, :controller
   alias FeedbackApi.{Survey, Repo}
+  alias FeedbackApiWeb.SurveyCreateFacade
 
   def index(conn, _params) do
     surveys = Survey |> Repo.all()
@@ -9,12 +10,9 @@ defmodule FeedbackApiWeb.SurveysController do
   end
 
   def create(conn, params) do
-    require IEx; IEx.pry()
-    survey = Survey.changeset(%Survey{}, params)
-
-    case Repo.insert(survey) do
-      {:ok, survey} -> render(conn, "show.json", survey: survey)
-      {:error, survey} -> json(conn, survey.errors)
+    case SurveyCreateFacade.create_survey(params) do
+      {:ok, _survey} -> conn |> put_status(:created) |> json(%{success: "Survey stored"})
+      {:error, survey} -> conn |> put_status(:unprocessable_entity) |> json(survey.errors)
     end
   end
 end

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -3,7 +3,7 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
   import Ecto.Query
 
   def create_survey(arguments) do
-    Repo.transaction(fn() ->
+    Repo.transaction(fn ->
       try do
         survey = Survey.changeset(%Survey{}, arguments) |> Repo.insert!()
         create_groups(survey, arguments["groups"])
@@ -43,6 +43,7 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
       |> Repo.preload([:survey, :answers])
 
     create_answers(new_question, question["answers"])
+
     Ecto.Changeset.change(new_question)
     |> Ecto.Changeset.put_assoc(:survey, survey)
     |> Repo.update!()

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -1,0 +1,63 @@
+defmodule FeedbackApiWeb.SurveyCreateFacade do
+  alias FeedbackApi.{Survey, User, Question, Group, Repo}
+  import Ecto.Query
+
+  def create_survey(arguments) do
+    try do
+      survey = Survey.changeset(%Survey{}, arguments) |> Repo.insert!()
+      create_groups(survey, arguments["groups"])
+      create_questions(survey, arguments["questions"])
+      {:ok, survey}
+    rescue
+      e in RuntimeError -> {:error, e}
+    end
+  end
+
+  defp create_groups(survey, groups) do
+    Enum.map(groups, fn group -> create_group(survey, group) end)
+  end
+
+  defp create_questions(survey, questions) do
+    Enum.map(questions, fn question -> create_question(survey, question) end)
+  end
+
+  defp create_group(survey, group) do
+    new_group =
+      Group.changeset(%Group{}, group) |> Repo.insert!() |> Repo.preload([:survey, :users])
+
+    users = Repo.all(from u in User, where: u.id in ^group["members_ids"])
+
+    group_associations_changeset =
+      Ecto.Changeset.change(new_group)
+      |> Ecto.Changeset.put_assoc(:survey, survey)
+      |> Ecto.Changeset.put_assoc(:users, users)
+
+    Repo.update!(group_associations_changeset)
+  end
+
+  defp create_question(survey, question) do
+    new_question =
+      Question.changeset(%Question{}, question)
+      |> Repo.insert!()
+      |> Repo.preload([:survey, :answers])
+
+    create_answers(new_question, question["answers"])
+    Ecto.Changeset.change(new_question)
+    |> Ecto.Changeset.put_assoc(:survey, survey)
+    |> Repo.update!()
+  end
+
+  defp create_answers(question, answers) do
+    Enum.map(answers, fn answer -> create_answer(question, answer) end)
+  end
+
+  defp create_answer(question, answer) do
+    new_answer =
+      Ecto.build_assoc(question, :answers, %{
+        description: answer["description"],
+        value: answer["value"]
+      })
+
+    Repo.insert!(new_answer)
+  end
+end

--- a/priv/repo/migrations/20190519175341_add-name-to-groups.exs
+++ b/priv/repo/migrations/20190519175341_add-name-to-groups.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.FeedbackApi.Repo.Migrations.Add-name-to-groups" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:groups) do
+      add :name, :string
+    end
+  end
+end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -15,9 +15,11 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   end
 
   test "Create new survey", %{conn: conn} do
+    conn = conn |> put_req_header("content-type", "application/json")
     body = File.read!("test/fixtures/survey_create.json")
-    conn = post(conn, "/api/v1/surveys")
+    conn = post(conn, "/api/v1/surveys", body)
     assert json_response(conn, 201) =~ ~s{"success": "survey stored"}
+    assert Cohort |> Repo.aggregate(:count, :id) == 1
   end
 
 end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -1,0 +1,23 @@
+defmodule FeedbackApiWeb.SurveysControllerTest do
+  use FeedbackApiWeb.ConnCase
+  alias FeedbackApi.{Cohort, User, Survey, Group, Repo}
+
+  setup do
+    cohorts = [%{id: 1, name: "1811", program: "b"}, %{id: 2, name: "1811", program: "f"}]
+    cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
+    Enum.map(cohort_changesets, fn changeset -> Repo.insert(changeset) end)
+    students = {
+      %{id: 1, cohort_id: 1}, %{id: 2, cohort_id: 1}, %{id: 3, cohort_id: 1},
+      %{id: 4, cohort_id: 2}, %{id: 5, cohort_id: 2}, %{id: 6, cohort_id: 2}
+    }
+    cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
+    Enum.map(cohort_changesets, fn changeset -> Repo.insert(changeset) end)
+  end
+
+  test "Create new survey", %{conn: conn} do
+    body = File.read!("test/fixtures/survey_create.json")
+    conn = post(conn, "/api/v1/surveys")
+    assert json_response(conn, 201) =~ ~s{"success": "survey stored"}
+  end
+
+end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -1,25 +1,30 @@
 defmodule FeedbackApiWeb.SurveysControllerTest do
   use FeedbackApiWeb.ConnCase
-  alias FeedbackApi.{Cohort, User, Survey, Group, Repo}
+  alias FeedbackApi.{Cohort, User, Survey, Repo}
 
   setup do
     cohorts = [%{id: 1, name: "1811", program: "b"}, %{id: 2, name: "1811", program: "f"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
     Enum.map(cohort_changesets, fn changeset -> Repo.insert(changeset) end)
-    students = {
-      %{id: 1, cohort_id: 1}, %{id: 2, cohort_id: 1}, %{id: 3, cohort_id: 1},
-      %{id: 4, cohort_id: 2}, %{id: 5, cohort_id: 2}, %{id: 6, cohort_id: 2}
-    }
-    cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
-    Enum.map(cohort_changesets, fn changeset -> Repo.insert(changeset) end)
+
+    students = [
+      %{id: 1, cohort_id: 1},
+      %{id: 2, cohort_id: 1},
+      %{id: 3, cohort_id: 1},
+      %{id: 4, cohort_id: 2},
+      %{id: 5, cohort_id: 2},
+      %{id: 6, cohort_id: 2}
+    ]
+
+    student_changesets = Enum.map(students, fn student -> User.changeset(%User{}, student) end)
+    Enum.map(student_changesets, fn changeset -> Repo.insert(changeset) end)
   end
 
   test "Create new survey", %{conn: conn} do
     conn = conn |> put_req_header("content-type", "application/json")
     body = File.read!("test/fixtures/survey_create.json")
     conn = post(conn, "/api/v1/surveys", body)
-    assert json_response(conn, 201) =~ ~s{"success": "survey stored"}
-    assert Cohort |> Repo.aggregate(:count, :id) == 1
+    assert json_response(conn, 201) == %{"success" => "Survey stored"}
+    assert Survey |> Repo.aggregate(:count, :id) == 1
   end
-
 end

--- a/test/fixtures/survey_create.json
+++ b/test/fixtures/survey_create.json
@@ -1,0 +1,47 @@
+{
+"api_key": "lkj4264lkmlkj98so9oug",
+"name": "1811 Cross-Pollination Project",
+"exp_date": "Mon May 20 2019 17:43:49 GMT-0600 (Mountain Daylight Time)",
+"questions": [
+  {
+    "id": 1,
+    "text": "How well did this person communicate with the rest of the team?",
+    "answers": [
+      {
+        "id": 1,
+        "value": 1,
+        "description": "The person did not follow up regularly and often demonstrated unclear or inconsistent communication."
+      },
+      {
+        "id": 2,
+        "value": 2,
+        "description": "The person was mostly consistent but was sometimes unclear in a way that slowed down the team or created frustration."
+      },
+      {
+        "id": 3,
+        "value": 3,
+        "description": "The person overall contributed positively in terms of communication."
+      },
+      {
+        "id": 4,
+        "value": 4,
+        "description": "The person demonstrated demonstrated clear and timely communication very consistently."
+      }
+    ]
+  }
+],
+"groups": [
+  {
+    "name": "Team1",
+    "members_ids": [
+      "7", "12", "4", "11"
+    ]
+  },
+  {
+    "name": "Team2",
+    "members_ids": [
+      "2", "13", "17", "9"
+    ]
+  }
+]
+}


### PR DESCRIPTION
Adds initial endpoint for creation of surveys. Endpoint returns a 201 if successful or a 422 if the request is unable to be processed. If invalid users are provided for groups, survey creation will still succeed. Testing is present for happy path.

@aprildagonese How do we want to handle the concept of a template? Do we need a new field on the survey post to indicate it is a template?

Also, the timestamp is still work in progress. I'll get that added and submit in a separate PR.