### PR TITLE
Create surveys index

### DIFF
--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -8,6 +8,7 @@ defmodule FeedbackApi.Survey do
   schema "surveys" do
     field :name, :string
     field :status, StatusEnum, default: :active
+    field :exp_date, :naive_datetime
     has_many :groups, FeedbackApi.Group
     has_many :questions, FeedbackApi.Question
 
@@ -17,7 +18,7 @@ defmodule FeedbackApi.Survey do
   @doc false
   def changeset(survey, attrs) do
     survey
-    |> cast(attrs, [:name, :status])
+    |> cast(attrs, [:name, :status, :exp_date])
     |> validate_required([:name, :status])
   end
 end

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -9,12 +9,13 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
         create_groups(survey, arguments["groups"])
         create_questions(survey, arguments["questions"])
       rescue
-        e -> Repo.rollback("Missing required fields")
+        _e -> Repo.rollback("Missing required fields")
       end
     end)
   end
 
   defp create_groups(survey, groups) do
+    IO.inspect(groups)
     Enum.map(groups, fn group -> create_group(survey, group) end)
   end
 
@@ -23,8 +24,10 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
   end
 
   defp create_group(survey, group) do
+    IO.puts "here"
     new_group =
       Group.changeset(%Group{}, group) |> Repo.insert!() |> Repo.preload([:survey, :users])
+    IO.inspect(new_group)
 
     users = Repo.all(from u in User, where: u.id in ^group["members_ids"])
 

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -15,7 +15,6 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
   end
 
   defp create_groups(survey, groups) do
-    IO.inspect(groups)
     Enum.map(groups, fn group -> create_group(survey, group) end)
   end
 

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -24,10 +24,8 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
   end
 
   defp create_group(survey, group) do
-    IO.puts "here"
     new_group =
       Group.changeset(%Group{}, group) |> Repo.insert!() |> Repo.preload([:survey, :users])
-    IO.inspect(new_group)
 
     users = Repo.all(from u in User, where: u.id in ^group["members_ids"])
 

--- a/lib/feedback_api_web/views/answer_view.ex
+++ b/lib/feedback_api_web/views/answer_view.ex
@@ -1,0 +1,16 @@
+defmodule FeedbackApiWeb.AnswerView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.AnswerView
+
+  def render("index.json", %{answers: answers}) do
+    render_many(answers, AnswerView, "answer.json")
+  end
+
+  def render("show.json", %{answer: answer}) do
+    render_one(answer, AnswerView, "answer.json")
+  end
+
+  def render("answer.json", %{answer: answer}) do
+    %{description: answer.description, value: answer.value}
+  end
+end

--- a/lib/feedback_api_web/views/group_view.ex
+++ b/lib/feedback_api_web/views/group_view.ex
@@ -1,0 +1,16 @@
+defmodule FeedbackApiWeb.GroupView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.GroupView
+
+  def render("index.json", %{groups: groups}) do
+    render_many(groups, GroupView, "group.json")
+  end
+
+  def render("show.json", %{group: group}) do
+    render_one(group, GroupView, "group.json")
+  end
+
+  def render("group.json", %{group: group}) do
+    %{name: group.name, member_ids: Enum.map(group.users, fn user -> user.id end)}
+  end
+end

--- a/lib/feedback_api_web/views/question_view.ex
+++ b/lib/feedback_api_web/views/question_view.ex
@@ -1,0 +1,16 @@
+defmodule FeedbackApiWeb.QuestionView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.{QuestionView, AnswerView}
+
+  def render("index.json", %{questions: questions}) do
+    render_many(questions, QuestionView, "question.json")
+  end
+
+  def render("show.json", %{question: question}) do
+    render_one(question, QuestionView, "question.json")
+  end
+
+  def render("question.json", %{question: question}) do
+    %{text: question.text, answers: render_many(question.answers, AnswerView, "answer.json")}
+  end
+end

--- a/lib/feedback_api_web/views/surveys_view.ex
+++ b/lib/feedback_api_web/views/surveys_view.ex
@@ -1,6 +1,6 @@
 defmodule FeedbackApiWeb.SurveysView do
   use FeedbackApiWeb, :view
-  alias FeedbackApiWeb.SurveysView
+  alias FeedbackApiWeb.{SurveysView, QuestionView, GroupView}
 
   def render("index.json", %{surveys: surveys}) do
     render_many(surveys, SurveysView, "survey.json")
@@ -11,6 +11,14 @@ defmodule FeedbackApiWeb.SurveysView do
   end
 
   def render("survey.json", %{surveys: survey}) do
-    %{id: survey.id, name: survey.name}
+    %{
+      id: survey.id,
+      name: survey.name,
+      status: survey.status,
+      created_at: survey.inserted_at,
+      updated_at: survey.updated_at,
+      questions: render_many(survey.questions, QuestionView, "question.json"),
+      groups: render_many(survey.groups, GroupView, "group.json")
+    }
   end
 end

--- a/lib/feedback_api_web/views/surveys_view.ex
+++ b/lib/feedback_api_web/views/surveys_view.ex
@@ -15,6 +15,7 @@ defmodule FeedbackApiWeb.SurveysView do
       id: survey.id,
       name: survey.name,
       status: survey.status,
+      exp_date: survey.exp_date,
       created_at: survey.inserted_at,
       updated_at: survey.updated_at,
       questions: render_many(survey.questions, QuestionView, "question.json"),

--- a/priv/repo/migrations/20190520004837_add_exp_date_to_survey.exs
+++ b/priv/repo/migrations/20190520004837_add_exp_date_to_survey.exs
@@ -1,0 +1,9 @@
+defmodule FeedbackApi.Repo.Migrations.AddExpDateToSurvey do
+  use Ecto.Migration
+
+  def change do
+    alter table(:surveys) do
+      add :exp_date, :naive_datetime
+    end
+  end
+end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -58,24 +58,24 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
     survey = Repo.one(Survey)
     conn = get(conn, "/api/v1/surveys")
 
-    expected = [%{
-      "groups" => [],
-      "name" => "A test survey",
-      "id" => survey.id,
-      "exp_date" => nil,
-      "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
-      "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
-      "questions" => [
-        %{
-          "answers" => [%{"description" => "A thing", "value" => 3}],
-          "text" => "What is this?"
-        }
-      ],
-      "status" => "active"
-    }
-  ]
+    expected = [
+      %{
+        "groups" => [],
+        "name" => "A test survey",
+        "id" => survey.id,
+        "exp_date" => nil,
+        "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+        "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
+        "questions" => [
+          %{
+            "answers" => [%{"description" => "A thing", "value" => 3}],
+            "text" => "What is this?"
+          }
+        ],
+        "status" => "active"
+      }
+    ]
 
     assert expected == json_response(conn, 200)
-
   end
 end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -62,6 +62,7 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
       "groups" => [],
       "name" => "A test survey",
       "id" => survey.id,
+      "exp_date" => nil,
       "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
       "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
       "questions" => [

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -40,7 +40,7 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   end
 
   test "Return all surveys", %{conn: conn} do
-    conn.get("/api/v1/surveys")
+    conn = get(conn, "/api/v1/surveys")
 
     assert json_response(conn, 200) == %{"surveys" => [
       %{

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -1,30 +1,69 @@
 defmodule FeedbackApiWeb.SurveysControllerTest do
   use FeedbackApiWeb.ConnCase
-  alias FeedbackApi.{Cohort, User, Survey, Repo}
+  alias FeedbackApi.{Cohort, Survey, Question, Repo}
 
   setup do
     cohorts = [%{id: 1, name: "1811", program: "b"}, %{id: 2, name: "1811", program: "f"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
-    Enum.map(cohort_changesets, fn changeset -> Repo.insert(changeset) end)
+    [cohort_1, cohort_2] = Enum.map(cohort_changesets, fn changeset -> Repo.insert!(changeset) |> Repo.preload([:users]) end)
 
-    students = [
+    cohort_1_students = [
       %{id: 1, cohort_id: 1},
       %{id: 2, cohort_id: 1},
-      %{id: 3, cohort_id: 1},
+      %{id: 3, cohort_id: 1}
+    ]
+    cohort_2_students = [
       %{id: 4, cohort_id: 2},
       %{id: 5, cohort_id: 2},
       %{id: 6, cohort_id: 2}
     ]
 
-    student_changesets = Enum.map(students, fn student -> User.changeset(%User{}, student) end)
-    Enum.map(student_changesets, fn changeset -> Repo.insert(changeset) end)
+    Enum.map(cohort_1_students, fn student -> Ecto.build_assoc(cohort_1, :users, student) |> Repo.insert!() end)
+    Enum.map(cohort_2_students, fn student -> Ecto.build_assoc(cohort_2, :users, student) |> Repo.insert!() end)
+
+    survey = Survey.changeset(%Survey{}, %{name: "A test survey"}) |> Repo.insert!()
+    question = Question.changeset(%Question{}, %{text: "What is this?"}) |> Repo.insert!() |> Repo.preload([:survey, :answers])
+    Ecto.build_assoc(question, :answers, %{description: "A thing", value: 3}) |> Repo.insert!()
+    Ecto.Changeset.change(question) |> Ecto.Changeset.put_assoc(:survey, survey) |> Repo.update!()
+    Ecto.build_assoc(survey, :groups, %{name: "Small group"})
+    :ok
   end
 
   test "Create new survey", %{conn: conn} do
     conn = conn |> put_req_header("content-type", "application/json")
     body = File.read!("test/fixtures/survey_create.json")
+
     conn = post(conn, "/api/v1/surveys", body)
+
     assert json_response(conn, 201) == %{"success" => "Survey stored"}
-    assert Survey |> Repo.aggregate(:count, :id) == 1
+    assert Survey |> Repo.aggregate(:count, :id) == 2
+  end
+
+  test "Return all surveys", %{conn: conn} do
+    conn.get("/api/v1/surveys")
+
+    assert json_response(conn, 200) == %{"surveys" => [
+      %{
+        "name" => "A test survey",
+        "questions" => [
+          %{
+            "text" => "What is this?",
+            "answers" => [
+              %{
+                "value" => 3,
+                "description" => "A thing"
+              }
+            ]
+          }
+        ]
+      }
+      ],
+    "groups" => [
+      %{
+        "name" => "Small group",
+        "members_ids" => []
+      }
+    ]
+  }
   end
 end

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -5,24 +5,39 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   setup do
     cohorts = [%{id: 1, name: "1811", program: "b"}, %{id: 2, name: "1811", program: "f"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
-    [cohort_1, cohort_2] = Enum.map(cohort_changesets, fn changeset -> Repo.insert!(changeset) |> Repo.preload([:users]) end)
+
+    [cohort_1, cohort_2] =
+      Enum.map(cohort_changesets, fn changeset ->
+        Repo.insert!(changeset) |> Repo.preload([:users])
+      end)
 
     cohort_1_students = [
       %{id: 1, cohort_id: 1},
       %{id: 2, cohort_id: 1},
       %{id: 3, cohort_id: 1}
     ]
+
     cohort_2_students = [
       %{id: 4, cohort_id: 2},
       %{id: 5, cohort_id: 2},
       %{id: 6, cohort_id: 2}
     ]
 
-    Enum.map(cohort_1_students, fn student -> Ecto.build_assoc(cohort_1, :users, student) |> Repo.insert!() end)
-    Enum.map(cohort_2_students, fn student -> Ecto.build_assoc(cohort_2, :users, student) |> Repo.insert!() end)
+    Enum.map(cohort_1_students, fn student ->
+      Ecto.build_assoc(cohort_1, :users, student) |> Repo.insert!()
+    end)
+
+    Enum.map(cohort_2_students, fn student ->
+      Ecto.build_assoc(cohort_2, :users, student) |> Repo.insert!()
+    end)
 
     survey = Survey.changeset(%Survey{}, %{name: "A test survey"}) |> Repo.insert!()
-    question = Question.changeset(%Question{}, %{text: "What is this?"}) |> Repo.insert!() |> Repo.preload([:survey, :answers])
+
+    question =
+      Question.changeset(%Question{}, %{text: "What is this?"})
+      |> Repo.insert!()
+      |> Repo.preload([:survey, :answers])
+
     Ecto.build_assoc(question, :answers, %{description: "A thing", value: 3}) |> Repo.insert!()
     Ecto.Changeset.change(question) |> Ecto.Changeset.put_assoc(:survey, survey) |> Repo.update!()
     Ecto.build_assoc(survey, :groups, %{name: "Small group"})
@@ -40,30 +55,26 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   end
 
   test "Return all surveys", %{conn: conn} do
+    survey = Repo.one(Survey)
     conn = get(conn, "/api/v1/surveys")
 
-    assert json_response(conn, 200) == %{"surveys" => [
-      %{
-        "name" => "A test survey",
-        "questions" => [
-          %{
-            "text" => "What is this?",
-            "answers" => [
-              %{
-                "value" => 3,
-                "description" => "A thing"
-              }
-            ]
-          }
-        ]
-      }
+    expected = [%{
+      "groups" => [],
+      "name" => "A test survey",
+      "id" => survey.id,
+      "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+      "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
+      "questions" => [
+        %{
+          "answers" => [%{"description" => "A thing", "value" => 3}],
+          "text" => "What is this?"
+        }
       ],
-    "groups" => [
-      %{
-        "name" => "Small group",
-        "members_ids" => []
-      }
-    ]
-  }
+      "status" => "active"
+    }
+  ]
+
+    assert expected == json_response(conn, 200)
+
   end
 end

--- a/test/fixtures/survey_create.json
+++ b/test/fixtures/survey_create.json
@@ -1,7 +1,7 @@
 {
 "api_key": "lkj4264lkmlkj98so9oug",
 "name": "1811 Cross-Pollination Project",
-"exp_date": "Mon May 20 2019 17:43:49 GMT-0600 (Mountain Daylight Time)",
+"exp_date": "2020-05-19T20:40:19",
 "questions": [
   {
     "id": 1,


### PR DESCRIPTION
Adds Surveys index endpoint for application

The endpoint responds with all surveys, in order of descending creation time (newest first).

Additionally, the exp_date column has been added to the schema. This timestamp must be provided in iso_8601 format, which is different from the spec. 