### PR TITLE
Add survey response averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Params: None
 
 Purpose: To retrieve all users stored in the database, with optional params
 
-Optional Params: 
+Optional Params:
 - `/api/v1/users?program=b`
 - `/api/v1/users?program=f`
 - `/api/v1/users?cohort=1811`
 - `/api/v1/users?cohort=1903`
 
 Sample Response:
-   
+
    ```
    [
     {
@@ -191,3 +191,109 @@ Sample Response:
    ]
 ```
 
+## `GET /api/v1/surveys/averages`
+
+Purpose: To retrive the average response values for a survey
+
+Params: None
+
+Sample Response:
+```
+{
+  "survey" => {
+    "id" => 1,
+    "name" => "Test survey",
+    "exp_date" => null,
+    "created_at" => "2019-05-23T05:24:58",
+    "updated_at" => "2019-05-23T05:24:58",
+    "status" => "active",
+    "questions" => [
+      {
+        "id" => 42,
+        "text" => "Pick a number between one and four",
+        "answers" => [
+          {"description" => "Four", "value" => 4},
+          {"description" => "Three", "value" => 3},
+          {"description" => "Two", "value" => 2},
+          {"description" => "One", "value" => 1}
+        ]
+      }
+    ],
+    "groups" => [
+        {
+          "member_ids" => [1, 2, 3],
+          "name" => "Test"
+        }
+      ]
+    },
+    "averages" => [
+      {
+        "question_id" => 42,
+        "text" => "Pick a number between one and four",
+        "average_rating" => 3.3333333333333333
+      }
+    ]
+  }
+```
+
+## `GET /api/v1/surveys/user_averages`
+
+Purpose: To retrive the average response values for a survey
+
+Params: None
+
+Sample Response:
+```
+{
+  "averages" => [
+    {
+      "average_rating" => 3.5000000000000000,
+      "question_id" => 42,
+      "user_id" => 1
+    },
+    {
+      "average_rating" => 3.0000000000000000,
+      "question_id" => 42,
+      "user_id" => 2
+      }
+    ],
+    "survey" => {
+      "created_at" => "2019-05-23T05:24:58",
+      "exp_date" => null,
+      "groups" => [
+        {
+          "member_ids" => [1, 2, 3],
+          "name" => "Test"
+          }
+        ],
+      "id" => 1,
+      "name" => "Test Survey",
+      "questions" => [
+        {
+          "answers" => [
+            {
+              "description" => "Four",
+              "value" => 4
+            },
+            {
+              "description" => "Three",
+              "value" => 3
+            },
+            {
+              "description" => "Two",
+              "value" => 2
+            },
+            {
+              "description" => "One",
+              "value" => 1
+            }
+          ],
+        "id" => 42,
+        "text" => "Pick a number between one and four"
+      }
+    ],
+    "status" => "active",
+    "updated_at" => "2019-05-23T05:24:58"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Optional Params:
 
 Sample Response:
 
-   ```
+   ``` JSON
    [
     {
         "cohort": "1903",
@@ -47,7 +47,7 @@ Purpose: To store a survey to the account of the user whose api_key is supplied 
 Required Params: `api_key={USER_API_KEY_HERE}`
 
 Sample Request Body:
-   ```
+   ``` JSON
    {
      "api_key": "lkj4264lkmlkj98so9oug",
      "name": "1811 Cross-Pollination Project",
@@ -103,7 +103,7 @@ Purpose: To retrieve all surveys associated with the user whose api_key is suppl
 Required Params: `api_key={USER_API_KEY_HERE}`
 
 Sample Response Body:
-   ```
+   ``` JSON
    {
      "api_key": "lkj4264lkmlkj98so9oug",
      "surveys": [
@@ -166,7 +166,7 @@ Purpose: To retrieve a list of all active cohorts.
 Params: None
 
 Sample Response:
-```
+``` JSON
    [
     {
         "id": 13,
@@ -198,39 +198,39 @@ Purpose: To retrive the average response values for a survey
 Params: None
 
 Sample Response:
-```
+``` JSON
 {
-  "survey" => {
-    "id" => 1,
-    "name" => "Test survey",
-    "exp_date" => null,
-    "created_at" => "2019-05-23T05:24:58",
-    "updated_at" => "2019-05-23T05:24:58",
-    "status" => "active",
-    "questions" => [
+  "survey": {
+    "id": 1,
+    "name": "Test survey",
+    "exp_date": null,
+    "created_at": "2019-05-23T05:24:58",
+    "updated_at": "2019-05-23T05:24:58",
+    "status": "active",
+    "questions": [
       {
-        "id" => 42,
-        "text" => "Pick a number between one and four",
-        "answers" => [
-          {"description" => "Four", "value" => 4},
-          {"description" => "Three", "value" => 3},
-          {"description" => "Two", "value" => 2},
-          {"description" => "One", "value" => 1}
+        "id": 42,
+        "text": "Pick a number between one and four",
+        "answers": [
+          {"description": "Four", "value": 4},
+          {"description": "Three", "value": 3},
+          {"description": "Two", "value": 2},
+          {"description": "One", "value": 1}
         ]
       }
     ],
-    "groups" => [
+    "groups": [
         {
-          "member_ids" => [1, 2, 3],
-          "name" => "Test"
+          "member_ids": [1, 2, 3],
+          "name": "Test"
         }
       ]
     },
-    "averages" => [
+    "averages": [
       {
-        "question_id" => 42,
-        "text" => "Pick a number between one and four",
-        "average_rating" => 3.3333333333333333
+        "question_id": 42,
+        "text": "Pick a number between one and four",
+        "average_rating": 3.3333333333333333
       }
     ]
   }
@@ -243,57 +243,57 @@ Purpose: To retrive the average response values for a survey
 Params: None
 
 Sample Response:
-```
+``` JSON
 {
-  "averages" => [
+  "averages": [
     {
-      "average_rating" => 3.5000000000000000,
-      "question_id" => 42,
-      "user_id" => 1
+      "average_rating": 3.5000000000000000,
+      "question_id": 42,
+      "user_id": 1
     },
     {
-      "average_rating" => 3.0000000000000000,
-      "question_id" => 42,
-      "user_id" => 2
+      "average_rating": 3.0000000000000000,
+      "question_id": 42,
+      "user_id": 2
       }
     ],
-    "survey" => {
-      "created_at" => "2019-05-23T05:24:58",
-      "exp_date" => null,
-      "groups" => [
+    "survey": {
+      "created_at": "2019-05-23T05:24:58",
+      "exp_date": null,
+      "groups": [
         {
-          "member_ids" => [1, 2, 3],
-          "name" => "Test"
+          "member_ids": [1, 2, 3],
+          "name": "Test"
           }
         ],
-      "id" => 1,
-      "name" => "Test Survey",
-      "questions" => [
+      "id": 1,
+      "name": "Test Survey",
+      "questions": [
         {
-          "answers" => [
+          "answers": [
             {
-              "description" => "Four",
-              "value" => 4
+              "description": "Four",
+              "value": 4
             },
             {
-              "description" => "Three",
-              "value" => 3
+              "description": "Three",
+              "value": 3
             },
             {
-              "description" => "Two",
-              "value" => 2
+              "description": "Two",
+              "value": 2
             },
             {
-              "description" => "One",
-              "value" => 1
+              "description": "One",
+              "value": 1
             }
           ],
-        "id" => 42,
-        "text" => "Pick a number between one and four"
+        "id": 42,
+        "text": "Pick a number between one and four"
       }
     ],
-    "status" => "active",
-    "updated_at" => "2019-05-23T05:24:58"
+    "status": "active",
+    "updated_at": "2019-05-23T05:24:58"
   }
 }
 ```

--- a/lib/feedback_api/question.ex
+++ b/lib/feedback_api/question.ex
@@ -6,6 +6,7 @@ defmodule FeedbackApi.Question do
     field :text, :string
     belongs_to :survey, FeedbackApi.Survey
     has_many :answers, FeedbackApi.Answer
+    has_many :responses, FeedbackApi.Response
 
     timestamps()
   end

--- a/lib/feedback_api/response.ex
+++ b/lib/feedback_api/response.ex
@@ -6,6 +6,7 @@ defmodule FeedbackApi.Response do
     belongs_to :answer, FeedbackApi.Answer
     belongs_to :reviewer, FeedbackApi.User
     belongs_to :recipient, FeedbackApi.User
+    belongs_to :question, FeedbackApi.Question
 
     timestamps()
   end

--- a/lib/feedback_api/response.ex
+++ b/lib/feedback_api/response.ex
@@ -3,11 +3,9 @@ defmodule FeedbackApi.Response do
   import Ecto.Changeset
 
   schema "responses" do
-    field :target_user, :id
-    field :response_user, :id
     belongs_to :answer, FeedbackApi.Answer
-    belongs_to :reviewer, FeedbackApi.User, define_field: :target_user
-    belongs_to :recipient, FeedbackApi.User, define_field: :response_user
+    belongs_to :reviewer, FeedbackApi.User
+    belongs_to :recipient, FeedbackApi.User
 
     timestamps()
   end

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -20,7 +20,8 @@ defmodule FeedbackApi.Survey do
   def changeset(survey, attrs) do
     survey
     |> cast(attrs, [:name, :status, :exp_date, :user_id])
-    |> validate_required([:name, :status]) # Re-add requirement following Auth
+    # Re-add requirement following Auth
+    |> validate_required([:name, :status])
   end
 
   def all do

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -1,7 +1,7 @@
 defmodule FeedbackApi.Survey do
   use Ecto.Schema
-  import Ecto.Changeset
-  import Ecto.Enum
+  import Ecto.{Enum, Query, Changeset}
+  alias FeedbackApi.{Survey, Question, Repo}
 
   defenum(StatusEnum, active: 0, closed: 1, disabled: 3)
 
@@ -20,5 +20,24 @@ defmodule FeedbackApi.Survey do
     survey
     |> cast(attrs, [:name, :status, :exp_date])
     |> validate_required([:name, :status])
+  end
+
+  def class_averages(survey_id) do
+    Repo.one(
+      from survey in Survey,
+      join: questions in assoc(survey, :questions),
+      join: answers in assoc(questions, :answers),
+      join: averages in subquery(
+        from q2 in Question,
+        join: a2 in assoc(q2, :answers),
+        join: responses in assoc(a2, :responses),
+        group_by: q2.id,
+        select: %{id: q2.id, text: q2.text, average: avg(a2.value)}
+      ),
+      on: questions.id == averages.id,
+      where: survey.id == ^survey_id,
+      select: %{survey: survey, averages: [averages]},
+      preload: [questions: {questions, answers: answers}]
+    )
   end
 end

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -34,7 +34,7 @@ defmodule FeedbackApi.Survey do
     )
   end
 
-  def class_averages(survey_id) do
+  def averages(survey_id) do
     Repo.one(
       from survey in Survey,
         join: questions in assoc(survey, :questions),

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -34,6 +34,19 @@ defmodule FeedbackApi.Survey do
     )
   end
 
+  def one(id) do
+    Repo.one(
+      from survey in Survey,
+        left_join: groups in assoc(survey, :groups),
+        left_join: users in assoc(groups, :users),
+        left_join: questions in assoc(survey, :questions),
+        left_join: answers in assoc(questions, :answers),
+        where: survey.id == ^id,
+        order_by: [desc: survey.inserted_at, desc: answers.value],
+        preload: [groups: {groups, users: users}, questions: {questions, answers: answers}]
+    )
+  end
+
   def averages(survey_id) do
     Repo.one(
       from survey in Survey,

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -50,6 +50,8 @@ defmodule FeedbackApi.Survey do
   def averages(survey_id) do
     Repo.one(
       from survey in Survey,
+        join: groups in assoc(survey, :groups),
+        join: users in assoc(groups, :users),
         join: questions in assoc(survey, :questions),
         join: answers in assoc(questions, :answers),
         join:
@@ -64,7 +66,7 @@ defmodule FeedbackApi.Survey do
         where: survey.id == ^survey_id,
         order_by: [asc: questions.id, desc: answers.value],
         select: %{survey: survey, averages: [averages]},
-        preload: [questions: {questions, answers: answers}]
+        preload: [groups: {groups, users: users}, questions: {questions, answers: answers}]
     )
   end
 

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -36,6 +36,7 @@ defmodule FeedbackApi.Survey do
       ),
       on: questions.id == averages.id,
       where: survey.id == ^survey_id,
+      order_by: [asc: questions.id, desc: answers.value],
       select: %{survey: survey, averages: [averages]},
       preload: [questions: {questions, answers: answers}]
     )

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -1,7 +1,7 @@
 defmodule FeedbackApi.Survey do
   use Ecto.Schema
   import Ecto.{Enum, Query, Changeset}
-  alias FeedbackApi.{Survey, Question, Repo}
+  alias FeedbackApi.{Survey, Question, User, Repo}
 
   defenum(StatusEnum, active: 0, closed: 1, disabled: 3)
 
@@ -22,27 +22,51 @@ defmodule FeedbackApi.Survey do
     |> validate_required([:name, :status])
   end
 
-  def class_averages(survey_id) do
-    Repo.one(
+  def all do
+    Repo.all(
       from survey in Survey,
-      join: questions in assoc(survey, :questions),
-      join: answers in assoc(questions, :answers),
-      join: averages in subquery(
-        from q2 in Question,
-        join: a2 in assoc(q2, :answers),
-        join: responses in assoc(a2, :responses),
-        group_by: q2.id,
-        select: %{id: q2.id, text: q2.text, average: avg(a2.value)}
-      ),
-      on: questions.id == averages.id,
-      where: survey.id == ^survey_id,
-      order_by: [asc: questions.id, desc: answers.value],
-      select: %{survey: survey, averages: [averages]},
-      preload: [questions: {questions, answers: answers}]
+        left_join: groups in assoc(survey, :groups),
+        left_join: users in assoc(groups, :users),
+        left_join: questions in assoc(survey, :questions),
+        left_join: answers in assoc(questions, :answers),
+        order_by: [desc: survey.inserted_at, desc: answers.value],
+        preload: [groups: {groups, users: users}, questions: {questions, answers: answers}]
     )
   end
 
-  def group_averages(survey_id, group_id) do
+  def class_averages(survey_id) do
+    Repo.one(
+      from survey in Survey,
+        join: questions in assoc(survey, :questions),
+        join: answers in assoc(questions, :answers),
+        join:
+          averages in subquery(
+            from q2 in Question,
+              join: a2 in assoc(q2, :answers),
+              join: responses in assoc(a2, :responses),
+              group_by: q2.id,
+              select: %{id: q2.id, text: q2.text, average: avg(a2.value)}
+          ),
+        on: questions.id == averages.id,
+        where: survey.id == ^survey_id,
+        order_by: [asc: questions.id, desc: answers.value],
+        select: %{survey: survey, averages: [averages]},
+        preload: [questions: {questions, answers: answers}]
+    )
+  end
 
+  def user_averages(survey_id) do
+    Repo.all(
+      from question in Question,
+        left_join: responses in assoc(question, :responses),
+        join: answers in assoc(responses, :answer),
+        where: question.survey_id == ^survey_id,
+        group_by: [question.id, responses.recipient_id],
+        select: %{
+          question_id: question.id,
+          user_id: responses.recipient_id,
+          average_rating: avg(answers.value)
+        }
+    )
   end
 end

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -1,7 +1,7 @@
 defmodule FeedbackApi.Survey do
   use Ecto.Schema
   import Ecto.{Enum, Query, Changeset}
-  alias FeedbackApi.{Survey, Question, User, Repo}
+  alias FeedbackApi.{Survey, Question, User, Repo, Group}
 
   defenum(StatusEnum, active: 0, closed: 1, disabled: 3)
 
@@ -20,7 +20,7 @@ defmodule FeedbackApi.Survey do
   def changeset(survey, attrs) do
     survey
     |> cast(attrs, [:name, :status, :exp_date, :user_id])
-    |> validate_required([:name, :status, :user_id])
+    |> validate_required([:name, :status]) # Re-add requirement following Auth
   end
 
   def all do

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -41,4 +41,8 @@ defmodule FeedbackApi.Survey do
       preload: [questions: {questions, answers: answers}]
     )
   end
+
+  def group_averages(survey_id, group_id) do
+
+  end
 end

--- a/lib/feedback_api/user.ex
+++ b/lib/feedback_api/user.ex
@@ -8,8 +8,8 @@ defmodule FeedbackApi.User do
     field :name, :string
     field :program, :string
     belongs_to :cohort, FeedbackApi.Cohort
-    has_many :responses, FeedbackApi.Response, foreign_key: :response_user
-    has_many :ratings, FeedbackApi.Response, foreign_key: :target_user
+    has_many :responses, FeedbackApi.Response, foreign_key: :reviewer_id
+    has_many :ratings, FeedbackApi.Response, foreign_key: :recipient_id
     many_to_many :groups, FeedbackApi.Group, join_through: FeedbackApi.GroupMember
 
     timestamps()

--- a/lib/feedback_api/user.ex
+++ b/lib/feedback_api/user.ex
@@ -1,7 +1,6 @@
 defmodule FeedbackApi.User do
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query
   import Ecto.Enum
 
   defenum(StatusEnum, active: 0, inactive: 1)

--- a/lib/feedback_api/user.ex
+++ b/lib/feedback_api/user.ex
@@ -11,8 +11,8 @@ defmodule FeedbackApi.User do
     field :program, :string
     field :status, StatusEnum
     belongs_to :cohort, FeedbackApi.Cohort
-    has_many :responses, FeedbackApi.Response, foreign_key: :response_user
-    has_many :ratings, FeedbackApi.Response, foreign_key: :target_user
+    has_many :responses, FeedbackApi.Response, foreign_key: :reviewer_id
+    has_many :ratings, FeedbackApi.Response, foreign_key: :recipient_id
     has_many :surveys, FeedbackApi.Survey
     many_to_many :groups, FeedbackApi.Group, join_through: FeedbackApi.GroupMember
 

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -3,8 +3,9 @@ defmodule FeedbackApiWeb.Surveys.AverageController do
   alias FeedbackApi.Survey
 
   def index(conn, params) do
-    import IEx; IEx.pry()
-    Survey.class_averages(params["surveys_id"])
+    averages = Survey.class_averages(params["surveys_id"])
+    
+    render(conn, "index.json", %{averages: averages})
   end
 
   def show(conn, params) do

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -1,9 +1,10 @@
 defmodule FeedbackApiWeb.Surveys.AverageController do
   use FeedbackApiWeb, :controller
-  alias FeedbackApiWeb.Survey
+  alias FeedbackApi.Survey
 
   def index(conn, params) do
-    Survey.survey_with_averages(params["survey_id"])
+    import IEx; IEx.pry()
+    Survey.class_averages(params["surveys_id"])
   end
 
   def show(conn, params) do

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -3,8 +3,8 @@ defmodule FeedbackApiWeb.Surveys.AverageController do
   alias FeedbackApi.Survey
 
   def index(conn, params) do
-    averages = Survey.class_averages(params["surveys_id"])
-    
+    averages = Survey.class_averages(params["survey_id"])
+
     render(conn, "index.json", %{averages: averages})
   end
 

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -9,9 +9,8 @@ defmodule FeedbackApiWeb.Surveys.AverageController do
   end
 
   def show(conn, params) do
-    average = Survey.group_averages(params["survey_id"], params["group_id"])
+    average = Survey.user_averages(params["survey_id"])
 
     render(conn, "show.json", %{average: average})
   end
-
 end

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -9,7 +9,9 @@ defmodule FeedbackApiWeb.Surveys.AverageController do
   end
 
   def show(conn, params) do
-    # Work in progress
+    average = Survey.group_averages(params["survey_id"], params["group_id"])
+
+    render(conn, "show.json", %{average: average})
   end
 
 end

--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -1,0 +1,13 @@
+defmodule FeedbackApiWeb.Surveys.AverageController do
+  use FeedbackApiWeb, :controller
+  alias FeedbackApiWeb.Survey
+
+  def index(conn, params) do
+    Survey.survey_with_averages(params["survey_id"])
+  end
+
+  def show(conn, params) do
+    # Work in progress
+  end
+
+end

--- a/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
@@ -4,7 +4,9 @@ defmodule FeedbackApiWeb.Surveys.UserAverageController do
 
   def show(conn, params) do
     average = Survey.user_averages(params["survey_id"])
+    survey = Survey.one(params["survey_id"])
+    data = %{average: average, survey: survey}
 
-    render(conn, "show.json", %{average: average})
+    render(conn, "show.json", %{average: data})
   end
 end

--- a/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
@@ -1,4 +1,4 @@
-defmodule FeedbackApiWeb.Survey.UserAverageController do
+defmodule FeedbackApiWeb.Surveys.UserAverageController do
   use FeedbackApiWeb, :controller
   alias FeedbackApi.Survey
 

--- a/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/user_average_controller.ex
@@ -1,9 +1,9 @@
-defmodule FeedbackApiWeb.Surveys.AverageController do
+defmodule FeedbackApiWeb.Survey.UserAverageController do
   use FeedbackApiWeb, :controller
   alias FeedbackApi.Survey
 
   def show(conn, params) do
-    average = Survey.averages(params["survey_id"])
+    average = Survey.user_averages(params["survey_id"])
 
     render(conn, "show.json", %{average: average})
   end

--- a/lib/feedback_api_web/controllers/surveys_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys_controller.ex
@@ -5,16 +5,7 @@ defmodule FeedbackApiWeb.SurveyController do
   import Ecto.Query
 
   def index(conn, _params) do
-    surveys =
-      Repo.all(
-        from survey in Survey,
-          left_join: groups in assoc(survey, :groups),
-          left_join: users in assoc(groups, :users),
-          left_join: questions in assoc(survey, :questions),
-          left_join: answers in assoc(questions, :answers),
-          order_by: [desc: survey.inserted_at, desc: answers.value],
-          preload: [groups: {groups, users: users}, questions: {questions, answers: answers}]
-      )
+    surveys = Survey.all()
 
     render(conn, "index.json", surveys: surveys)
   end

--- a/lib/feedback_api_web/controllers/users_controller.ex
+++ b/lib/feedback_api_web/controllers/users_controller.ex
@@ -12,25 +12,41 @@ defmodule FeedbackApiWeb.UsersController do
   end
 
   def index(conn, params) do
-    users = case params do
-      %{"cohort" => cohort, "program" => program} -> Repo.all(from u in User,
-                                                join: cohorts in assoc(u, :cohort),
-                                                where: cohorts.name == ^cohort,
-                                                where: u.program == ^String.upcase(program),
-                                                preload: [cohort: cohorts])
-      %{"cohort" => cohort} -> Repo.all(from u in User,
-                                join: cohorts in assoc(u, :cohort),
-                                where: cohorts.name == ^cohort,
-                                preload: [cohort: cohorts])
-      %{"program" => program} -> Repo.all(from u in User,
-                                    join: cohorts in assoc(u, :cohort),
-                                    where: u.program == ^String.upcase(program),
-                                    preload: [cohort: cohorts])
-      %{} -> Repo.all(from u in User,
-                join: cohorts in assoc(u, :cohort),
-                preload: [cohort: cohorts])
+    users =
+      case params do
+        %{"cohort" => cohort, "program" => program} ->
+          Repo.all(
+            from u in User,
+              join: cohorts in assoc(u, :cohort),
+              where: cohorts.name == ^cohort,
+              where: u.program == ^String.upcase(program),
+              preload: [cohort: cohorts]
+          )
 
-    end
+        %{"cohort" => cohort} ->
+          Repo.all(
+            from u in User,
+              join: cohorts in assoc(u, :cohort),
+              where: cohorts.name == ^cohort,
+              preload: [cohort: cohorts]
+          )
+
+        %{"program" => program} ->
+          Repo.all(
+            from u in User,
+              join: cohorts in assoc(u, :cohort),
+              where: u.program == ^String.upcase(program),
+              preload: [cohort: cohorts]
+          )
+
+        %{} ->
+          Repo.all(
+            from u in User,
+              join: cohorts in assoc(u, :cohort),
+              preload: [cohort: cohorts]
+          )
+      end
+
     render(conn, "index.json", users: users)
   end
 end

--- a/lib/feedback_api_web/controllers/users_controller.ex
+++ b/lib/feedback_api_web/controllers/users_controller.ex
@@ -4,7 +4,7 @@ defmodule FeedbackApiWeb.UsersController do
   alias FeedbackApiWeb.UsersUpdateFacade
 
   def create(conn, _params) do
-    case UsersUpdateFacade.update_data do
+    case UsersUpdateFacade.update_data() do
       {:ok, _users} -> conn |> put_status(:created) |> json(%{success: "Data refreshed"})
       {:error, error} -> conn |> put_status(:request_timeout) |> json(%{error: error})
     end

--- a/lib/feedback_api_web/endpoint.ex
+++ b/lib/feedback_api_web/endpoint.ex
@@ -33,7 +33,9 @@ defmodule FeedbackApiWeb.Endpoint do
 
   plug Plug.MethodOverride
   plug Plug.Head
-  plug Corsica, origins: ["http://localhost:3000", "http://herokuapp.com", "https://herokuapp.com"]
+
+  plug Corsica,
+    origins: ["http://localhost:3000", "http://herokuapp.com", "https://herokuapp.com"]
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/lib/feedback_api_web/facades/users_update_facade.ex
+++ b/lib/feedback_api_web/facades/users_update_facade.ex
@@ -16,6 +16,7 @@ defmodule FeedbackApiWeb.UsersUpdateFacade do
 
   def update_cohorts do
     cohorts = Rooster.cohorts()
+
     Enum.map(cohorts, fn cohort ->
       refresh_cohort(cohort)
     end)
@@ -24,6 +25,7 @@ defmodule FeedbackApiWeb.UsersUpdateFacade do
   def refresh_cohort(cohort) do
     name = cohort["attributes"]["name"]
     status = cohort["attributes"]["status"]
+
     result =
       case Repo.get_by(Cohort, %{name: name}) do
         nil -> %Cohort{}
@@ -40,6 +42,7 @@ defmodule FeedbackApiWeb.UsersUpdateFacade do
 
   def update_students do
     cohorts = Rooster.students()
+
     Enum.map(cohorts, fn cohort ->
       get_students(cohort)
     end)
@@ -49,6 +52,7 @@ defmodule FeedbackApiWeb.UsersUpdateFacade do
     name = cohort_data["attributes"]["name"]
     cohort = Repo.get_by(Cohort, name: name)
     students = cohort_data["attributes"]["students"]
+
     Enum.map(students, fn student ->
       update_student(student, cohort)
     end)
@@ -58,6 +62,7 @@ defmodule FeedbackApiWeb.UsersUpdateFacade do
     name = student["name"]
     program = student["program"]
     cohort = Repo.preload(cohort, [:users])
+
     result =
       case Repo.get_by(User, %{name: name}) do
         nil -> %User{}

--- a/lib/feedback_api_web/router.ex
+++ b/lib/feedback_api_web/router.ex
@@ -22,7 +22,9 @@ defmodule FeedbackApiWeb.Router do
   scope "/api/v1", FeedbackApiWeb do
     pipe_through :api
 
-    resources "/surveys", SurveysController, only: [:index, :create]
+    resources "/surveys", SurveysController, only: [:index, :create] do
+      resources "/averages", Surveys.AverageController, only: [:index, :show]
+    end
     resources "/users", UsersController, only: [:index, :create]
   end
 end

--- a/lib/feedback_api_web/router.ex
+++ b/lib/feedback_api_web/router.ex
@@ -23,7 +23,8 @@ defmodule FeedbackApiWeb.Router do
     pipe_through :api
 
     resources "/surveys", SurveyController, only: [:index, :create] do
-      resources "/averages", Surveys.AverageController, only: [:index, :show]
+      get "/averages", Surveys.AverageController, :show
+      get "/user_averages", Surveys.UserAverageController, :show
     end
 
     resources "/users", UsersController, only: [:index, :create]

--- a/lib/feedback_api_web/views/question_view.ex
+++ b/lib/feedback_api_web/views/question_view.ex
@@ -11,6 +11,10 @@ defmodule FeedbackApiWeb.QuestionView do
   end
 
   def render("question.json", %{question: question}) do
-    %{id: question.id, text: question.text, answers: render_many(question.answers, AnswerView, "answer.json")}
+    %{
+      id: question.id,
+      text: question.text,
+      answers: render_many(question.answers, AnswerView, "answer.json")
+    }
   end
 end

--- a/lib/feedback_api_web/views/question_view.ex
+++ b/lib/feedback_api_web/views/question_view.ex
@@ -11,6 +11,6 @@ defmodule FeedbackApiWeb.QuestionView do
   end
 
   def render("question.json", %{question: question}) do
-    %{text: question.text, answers: render_many(question.answers, AnswerView, "answer.json")}
+    %{id: question.id, text: question.text, answers: render_many(question.answers, AnswerView, "answer.json")}
   end
 end

--- a/lib/feedback_api_web/views/surveys/average_view.ex
+++ b/lib/feedback_api_web/views/surveys/average_view.ex
@@ -1,6 +1,6 @@
 defmodule FeedbackApiWeb.Surveys.AverageView do
   use FeedbackApiWeb, :view
-  alias FeedbackApiWeb.{QuestionView, Surveys.AverageView}
+  alias FeedbackApiWeb.{SurveyView, Surveys.AverageView}
 
   def render("show.json", %{average: average}) do
     render_one(average, AverageView, "average.json")
@@ -8,13 +8,7 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
 
   def render("average.json", %{average: average}) do
     %{
-      id: average.survey.id,
-      name: average.survey.name,
-      status: average.survey.status,
-      exp_date: average.survey.exp_date,
-      created_at: average.survey.inserted_at,
-      updated_at: average.survey.updated_at,
-      questions: render_many(average.survey.questions, QuestionView, "question.json"),
+      survey: render_one(average.survey, SurveyView, "survey.json"),
       averages:
         Enum.map(average.averages, fn average ->
           %{

--- a/lib/feedback_api_web/views/surveys/average_view.ex
+++ b/lib/feedback_api_web/views/surveys/average_view.ex
@@ -3,14 +3,14 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
   alias FeedbackApiWeb.{QuestionView, Surveys.AverageView}
 
   def render("index.json", %{averages: averages}) do
-    render_one(averages, AverageView, "average.json")
+    render_one(averages, AverageView, "class_average.json")
   end
 
   def render("show.json", %{average: average}) do
-    render_one(average, AverageView, "average.json")
+    render_one(average, AverageView, "group_average.json")
   end
 
-  def render("average.json", %{average: average}) do
+  def render("class_average.json", %{average: average}) do
     %{
       id: average.survey.id,
       name: average.survey.name,
@@ -25,5 +25,9 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
         average_rating: average.average
         } end)
     }
+  end
+
+  def render("group_average.json", %{average: average}) do
+    %{}
   end
 end

--- a/lib/feedback_api_web/views/surveys/average_view.ex
+++ b/lib/feedback_api_web/views/surveys/average_view.ex
@@ -2,10 +2,6 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
   use FeedbackApiWeb, :view
   alias FeedbackApiWeb.{QuestionView, Surveys.AverageView}
 
-  def render("index.json", %{averages: averages}) do
-    render_one(averages, AverageView, "average.json")
-  end
-
   def render("show.json", %{average: average}) do
     render_one(average, AverageView, "average.json")
   end

--- a/lib/feedback_api_web/views/surveys/average_view.ex
+++ b/lib/feedback_api_web/views/surveys/average_view.ex
@@ -1,0 +1,29 @@
+defmodule FeedbackApiWeb.Surveys.AverageView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.{QuestionView, Surveys.AverageView}
+
+  def render("index.json", %{averages: averages}) do
+    render_one(averages, AverageView, "average.json")
+  end
+
+  def render("show.json", %{average: average}) do
+    render_one(average, AverageView, "average.json")
+  end
+
+  def render("average.json", %{average: average}) do
+    %{
+      id: average.survey.id,
+      name: average.survey.name,
+      status: average.survey.status,
+      exp_date: average.survey.exp_date,
+      created_at: average.survey.inserted_at,
+      updated_at: average.survey.updated_at,
+      questions: render_many(average.survey.questions, QuestionView, "question.json"),
+      averages: Enum.map(average.averages, fn average -> %{
+        question_id: average.id,
+        text: average.text,
+        average_rating: average.average
+        } end)
+    }
+  end
+end

--- a/lib/feedback_api_web/views/surveys/average_view.ex
+++ b/lib/feedback_api_web/views/surveys/average_view.ex
@@ -3,14 +3,14 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
   alias FeedbackApiWeb.{QuestionView, Surveys.AverageView}
 
   def render("index.json", %{averages: averages}) do
-    render_one(averages, AverageView, "class_average.json")
+    render_one(averages, AverageView, "average.json")
   end
 
   def render("show.json", %{average: average}) do
-    render_one(average, AverageView, "group_average.json")
+    render_one(average, AverageView, "average.json")
   end
 
-  def render("class_average.json", %{average: average}) do
+  def render("average.json", %{average: average}) do
     %{
       id: average.survey.id,
       name: average.survey.name,
@@ -19,15 +19,14 @@ defmodule FeedbackApiWeb.Surveys.AverageView do
       created_at: average.survey.inserted_at,
       updated_at: average.survey.updated_at,
       questions: render_many(average.survey.questions, QuestionView, "question.json"),
-      averages: Enum.map(average.averages, fn average -> %{
-        question_id: average.id,
-        text: average.text,
-        average_rating: average.average
-        } end)
+      averages:
+        Enum.map(average.averages, fn average ->
+          %{
+            question_id: average.id,
+            text: average.text,
+            average_rating: average.average
+          }
+        end)
     }
-  end
-
-  def render("group_average.json", %{average: average}) do
-    %{}
   end
 end

--- a/lib/feedback_api_web/views/surveys/user_average_view.ex
+++ b/lib/feedback_api_web/views/surveys/user_average_view.ex
@@ -1,14 +1,20 @@
 defmodule FeedbackApiWeb.Surveys.UserAverageView do
   use FeedbackApiWeb, :view
-  alias FeedbackApiWeb.{QuestionView, Surveys.UserAverageView}
+  alias FeedbackApiWeb.{QuestionView, Surveys.UserAverageView, SurveyView}
 
   def render("show.json", %{average: average}) do
     render_one(average, UserAverageView, "user_average.json")
   end
 
   def render("user_average.json", %{user_average: user_average}) do
+    import IEx; IEx.pry()
     %{
-      
+      survey: render_one(user_average.survey, SurveyView, "survey.json"),
+      averages: Enum.map(user_average.average, fn user -> %{
+        user_id: user.user_id,
+        question_id: user.question_id,
+        average_rating: user.average_rating
+        } end)
     }
   end
 end

--- a/lib/feedback_api_web/views/surveys/user_average_view.ex
+++ b/lib/feedback_api_web/views/surveys/user_average_view.ex
@@ -9,12 +9,14 @@ defmodule FeedbackApiWeb.Surveys.UserAverageView do
   def render("user_average.json", %{user_average: user_average}) do
     %{
       survey: render_one(user_average.survey, SurveyView, "survey.json"),
-      averages: Enum.map(user_average.average, fn user -> %{
-        user_id: user.user_id,
-        question_id: user.question_id,
-        average_rating: user.average_rating
-        }
-      end)
+      averages:
+        Enum.map(user_average.average, fn user ->
+          %{
+            user_id: user.user_id,
+            question_id: user.question_id,
+            average_rating: user.average_rating
+          }
+        end)
     }
   end
 end

--- a/lib/feedback_api_web/views/surveys/user_average_view.ex
+++ b/lib/feedback_api_web/views/surveys/user_average_view.ex
@@ -7,14 +7,14 @@ defmodule FeedbackApiWeb.Surveys.UserAverageView do
   end
 
   def render("user_average.json", %{user_average: user_average}) do
-    import IEx; IEx.pry()
     %{
       survey: render_one(user_average.survey, SurveyView, "survey.json"),
       averages: Enum.map(user_average.average, fn user -> %{
         user_id: user.user_id,
         question_id: user.question_id,
         average_rating: user.average_rating
-        } end)
+        }
+      end)
     }
   end
 end

--- a/lib/feedback_api_web/views/surveys/user_average_view.ex
+++ b/lib/feedback_api_web/views/surveys/user_average_view.ex
@@ -1,0 +1,14 @@
+defmodule FeedbackApiWeb.Surveys.UserAverageView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.{QuestionView, Surveys.UserAverageView}
+
+  def render("show.json", %{average: average}) do
+    render_one(average, UserAverageView, "user_average.json")
+  end
+
+  def render("user_average.json", %{user_average: user_average}) do
+    %{
+      
+    }
+  end
+end

--- a/lib/feedback_api_web/views/users_view.ex
+++ b/lib/feedback_api_web/views/users_view.ex
@@ -11,6 +11,12 @@ defmodule FeedbackApiWeb.UsersView do
   end
 
   def render("user.json", %{users: user}) do
-    %{id: user.id, name: user.name, program: user.program, cohort: user.cohort.name, status: user.status}
+    %{
+      id: user.id,
+      name: user.name,
+      program: user.program,
+      cohort: user.cohort.name,
+      status: user.status
+    }
   end
 end

--- a/priv/repo/migrations/20190522000229_update_reference_names_on_response.exs
+++ b/priv/repo/migrations/20190522000229_update_reference_names_on_response.exs
@@ -1,0 +1,16 @@
+defmodule FeedbackApi.Repo.Migrations.UpdateReferenceNamesOnResponse do
+  use Ecto.Migration
+
+  def change do
+    alter table(:responses) do
+      remove :target_user
+      remove :response_user
+      add :recipient_id, references(:users, on_delete: :nothing)
+      add :reviewer_id, references(:users, on_delete: :nothing)
+      
+    end
+
+    create index(:responses, [:recipient_id])
+    create index(:responses, [:reviewer_id])
+  end
+end

--- a/priv/repo/migrations/20190522000229_update_reference_names_on_response.exs
+++ b/priv/repo/migrations/20190522000229_update_reference_names_on_response.exs
@@ -7,7 +7,6 @@ defmodule FeedbackApi.Repo.Migrations.UpdateReferenceNamesOnResponse do
       remove :response_user
       add :recipient_id, references(:users, on_delete: :nothing)
       add :reviewer_id, references(:users, on_delete: :nothing)
-      
     end
 
     create index(:responses, [:recipient_id])

--- a/priv/repo/migrations/20190522212411_add_question_references_to_responses.exs
+++ b/priv/repo/migrations/20190522212411_add_question_references_to_responses.exs
@@ -1,0 +1,11 @@
+defmodule FeedbackApi.Repo.Migrations.AddQuestionReferencesToResponses do
+  use Ecto.Migration
+
+  def change do
+    alter table(:responses) do
+      add :question_id, references(:questions, on_delete: :nothing)
+    end
+
+    create index(:responses, [:question_id])
+  end
+end

--- a/test/feedback_api_web/controllers/cohorts_controller_test.exs
+++ b/test/feedback_api_web/controllers/cohorts_controller_test.exs
@@ -3,7 +3,7 @@ defmodule FeedbackApiWeb.CohortsControllerTest do
   alias FeedbackApi.{Repo, Cohort}
 
   setup do
-    cohorts = [%{id: 1, name: "1811"}, %{id: 2, name: "1901"}]
+    cohorts = [%{id: 1, status: :Active, name: "1811"}, %{id: 2, status: :Active, name: "1901"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
     Enum.map(cohort_changesets, fn changeset ->
       Repo.insert!(changeset)
@@ -17,9 +17,11 @@ defmodule FeedbackApiWeb.CohortsControllerTest do
 
     expected = [
       %{"name" => "1811",
-        "id" => cohort_1.id},
+        "id" => cohort_1.id,
+        "status" => "Active"},
       %{"name" => "1901",
-        "id" => cohort_2.id}
+        "id" => cohort_2.id,
+        "status" => "Active"}
     ]
 
     assert json_response(conn, 200) == expected

--- a/test/feedback_api_web/controllers/cohorts_controller_test.exs
+++ b/test/feedback_api_web/controllers/cohorts_controller_test.exs
@@ -5,23 +5,21 @@ defmodule FeedbackApiWeb.CohortsControllerTest do
   setup do
     cohorts = [%{id: 1, status: :Active, name: "1811"}, %{id: 2, status: :Active, name: "1901"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
+
     Enum.map(cohort_changesets, fn changeset ->
       Repo.insert!(changeset)
     end)
+
     :ok
   end
 
   test "It returns a list of all cohorts", %{conn: conn} do
-    [cohort_1, cohort_2] = Cohort |> Repo.all
+    [cohort_1, cohort_2] = Cohort |> Repo.all()
     conn = get(conn, "/api/v1/cohorts")
 
     expected = [
-      %{"name" => "1811",
-        "id" => cohort_1.id,
-        "status" => "Active"},
-      %{"name" => "1901",
-        "id" => cohort_2.id,
-        "status" => "Active"}
+      %{"name" => "1811", "id" => cohort_1.id, "status" => "Active"},
+      %{"name" => "1901", "id" => cohort_2.id, "status" => "Active"}
     ]
 
     assert json_response(conn, 200) == expected

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -3,9 +3,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
   alias FeedbackApi.{Cohort, Group, Survey, Question, Repo}
 
   setup do
-    survey = %Survey{name: "Test Survey"} |> Repo.insert!() |> Repo.preload([:groups, :questions])
     cohort = %Cohort{name: "1811", status: :Active} |> Repo.insert!() |> Repo.preload(:users)
-
     students = [
       %{name: "User 1", program: "B"},
       %{name: "User 2", program: "B"},
@@ -18,6 +16,10 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
         |> Repo.insert!()
         |> Repo.preload([:responses, :ratings])
       end)
+
+    # User_1 : 3.5, User_2 : 3, User_3 : nil
+    [user_1, user_2, user_3] = users
+    survey = Ecto.build_assoc(user_3, :surveys, %Survey{name: "Test Survey"}) |> Repo.insert!() |> Repo.preload([:groups, :questions])
 
     group =
       Ecto.build_assoc(survey, :groups, %{name: "Test"})
@@ -43,8 +45,6 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
         Ecto.build_assoc(question, :answers, answer) |> Repo.insert!()
       end)
 
-    # User_1 : 3.5, User_2 : 3, User_3 : nil
-    [user_1, user_2, user_3] = users
 
     response_1 =
       Ecto.build_assoc(answer_4, :responses, %{})

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -5,35 +5,89 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
   setup do
     survey = %Survey{name: "Test Survey"} |> Repo.insert!() |> Repo.preload([:groups, :questions])
     cohort = %Cohort{name: "1811", status: :Active} |> Repo.insert!() |> Repo.preload(:users)
+
     students = [
       %{name: "User 1", program: "B"},
       %{name: "User 2", program: "B"},
       %{name: "User 3", program: "B"}
     ]
-    users = Enum.map(students, fn student -> Ecto.build_assoc(cohort, :users, student) |> Repo.preload([:ratings]) end)
-    group = Ecto.build_assoc(survey, :groups, %{name: "Test"}) |> Repo.insert!() |> Repo.preload([:users, :survey])
+
+    users =
+      Enum.map(students, fn student ->
+        Ecto.build_assoc(cohort, :users, student)
+        |> Repo.insert!()
+        |> Repo.preload([:responses, :ratings])
+      end)
+
+    group =
+      Ecto.build_assoc(survey, :groups, %{name: "Test"})
+      |> Repo.insert!()
+      |> Repo.preload([:users, :survey])
+
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(group), :users, users) |> Repo.update!()
-    question = Ecto.build_assoc(survey, :questions, %{text: "Pick a number between one and four"}) |> Repo.insert! |> Repo.preload(:answers)
+
+    question =
+      Ecto.build_assoc(survey, :questions, %{text: "Pick a number between one and four"})
+      |> Repo.insert!()
+      |> Repo.preload(:answers)
+
     answer_list = [
       %{description: "One", value: 1},
       %{description: "Two", value: 2},
       %{description: "Three", value: 3},
       %{description: "Four", value: 4}
     ]
-    [answer_1, answer_2, answer_3, answer_4] = Enum.map(answer_list, fn answer -> Ecto.build_assoc(question, :answers, answer) |> Repo.insert!() end)
-    [user_1, user_2, user_3] = users # User_1 : 3.5, User_2 : 3, User_3 : nil
-    response_1 = Ecto.build_assoc(answer_4, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :recipient, user_1) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :reviewer, user_3) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :question, question) |> Repo.update!()
-    response_2 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :recipient, user_1) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :reviewer, user_2) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :question, question) |> Repo.update!()
-    response_3 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :recipient, user_2) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :reviewer, user_1) |> Repo.update!()
-    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :question, question) |> Repo.update!()
+
+    [answer_1, answer_2, answer_3, answer_4] =
+      Enum.map(answer_list, fn answer ->
+        Ecto.build_assoc(question, :answers, answer) |> Repo.insert!()
+      end)
+
+    # User_1 : 3.5, User_2 : 3, User_3 : nil
+    [user_1, user_2, user_3] = users
+
+    response_1 =
+      Ecto.build_assoc(answer_4, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :recipient, user_1)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :reviewer, user_3)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :question, question)
+    |> Repo.update!()
+
+    response_2 =
+      Ecto.build_assoc(answer_3, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :recipient, user_1)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :reviewer, user_2)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :question, question)
+    |> Repo.update!()
+
+    response_3 =
+      Ecto.build_assoc(answer_3, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :recipient, user_2)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :reviewer, user_1)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :question, question)
+    |> Repo.update!()
+
     :ok
   end
 
@@ -73,7 +127,6 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
     }
 
     assert json_response(conn, 200) == expected
-
   end
 
   test "It can return the results from a survey for a group", %{conn: conn} do
@@ -96,10 +149,10 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
         %{
           "text" => "Pick a number between one and four",
           "answers" => [
-              %{"description" => "Four", "value" => 4},
-              %{"description" => "Three", "value" => 3},
-              %{"description" => "Two", "value" => 2},
-              %{"description" => "One", "value" => 1}
+            %{"description" => "Four", "value" => 4},
+            %{"description" => "Three", "value" => 3},
+            %{"description" => "Two", "value" => 2},
+            %{"description" => "One", "value" => 1}
           ]
         }
       ],

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -4,6 +4,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
 
   setup do
     cohort = %Cohort{name: "1811", status: :Active} |> Repo.insert!() |> Repo.preload(:users)
+
     students = [
       %{name: "User 1", program: "B"},
       %{name: "User 2", program: "B"},
@@ -19,7 +20,11 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
 
     # User_1 : 3.5, User_2 : 3, User_3 : nil
     [user_1, user_2, user_3] = users
-    survey = Ecto.build_assoc(user_3, :surveys, %Survey{name: "Test Survey"}) |> Repo.insert!() |> Repo.preload([:groups, :questions])
+
+    survey =
+      Ecto.build_assoc(user_3, :surveys, %Survey{name: "Test Survey"})
+      |> Repo.insert!()
+      |> Repo.preload([:groups, :questions])
 
     group =
       Ecto.build_assoc(survey, :groups, %{name: "Test"})
@@ -44,7 +49,6 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
       Enum.map(answer_list, fn answer ->
         Ecto.build_assoc(question, :answers, answer) |> Repo.insert!()
       end)
-
 
     response_1 =
       Ecto.build_assoc(answer_4, :responses, %{})
@@ -125,17 +129,17 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
           %{
             "member_ids" => [user_1.id, user_2.id, user_3.id],
             "name" => "Test"
-            }
-          ]
-        },
-        "averages" => [
-          %{
-            "question_id" => question.id,
-            "text" => question.text,
-            "average_rating" => "3.3333333333333333"
           }
         ]
-      }
+      },
+      "averages" => [
+        %{
+          "question_id" => question.id,
+          "text" => question.text,
+          "average_rating" => "3.3333333333333333"
+        }
+      ]
+    }
 
     assert json_response(conn, 200) == expected
   end
@@ -160,39 +164,39 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
           "average_rating" => "3.0000000000000000",
           "question_id" => question.id,
           "user_id" => user_2.id
+        }
+      ],
+      "survey" => %{
+        "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+        "exp_date" => nil,
+        "groups" => [
+          %{
+            "member_ids" => [user_1.id, user_2.id, user_3.id],
+            "name" => "Test"
           }
         ],
-        "survey" => %{
-          "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
-          "exp_date" => nil,
-          "groups" => [
-            %{
-              "member_ids" => [user_1.id, user_2.id, user_3.id],
-              "name" => "Test"
+        "id" => survey.id,
+        "name" => "Test Survey",
+        "questions" => [
+          %{
+            "answers" => [
+              %{
+                "description" => "Four",
+                "value" => 4
+              },
+              %{
+                "description" => "Three",
+                "value" => 3
+              },
+              %{
+                "description" => "Two",
+                "value" => 2
+              },
+              %{
+                "description" => "One",
+                "value" => 1
               }
             ],
-          "id" => survey.id,
-          "name" => "Test Survey",
-          "questions" => [
-            %{
-              "answers" => [
-                %{
-                  "description" => "Four",
-                  "value" => 4
-                },
-                %{
-                  "description" => "Three",
-                  "value" => 3
-                },
-                %{
-                  "description" => "Two",
-                  "value" => 2
-                },
-                %{
-                  "description" => "One",
-                  "value" => 1
-                }
-              ],
             "id" => question.id,
             "text" => "Pick a number between one and four"
           }

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -36,6 +36,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
 
   test "It can return the results from a survey for all groups", %{conn: conn} do
     survey = Repo.one(Survey)
+    question = Repo.one(Question)
     uri = "/api/v1/surveys/#{survey.id}/averages"
 
     conn = get(conn, uri)
@@ -49,14 +50,21 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
       "status" => "active",
       "questions" => [
         %{
+          "id" => question.id,
           "text" => "Pick a number between one and four",
-          "average_rating" => 3.25,
           "answers" => [
-              %{"description" => "One", "value" => 1},
-              %{"description" => "Two", "value" => 2},
-              %{"description" => "Three", "value" => 3},
-              %{"description" => "Four", "value" => 4}
+            %{"description" => "Four", "value" => 4},
+            %{"description" => "Three", "value" => 3},
+            %{"description" => "Two", "value" => 2},
+            %{"description" => "One", "value" => 1}
           ]
+        }
+      ],
+      "averages" => [
+        %{
+          "question_id" => question.id,
+          "text" => question.text,
+          "average_rating" => "3.3333333333333333"
         }
       ]
     }
@@ -85,10 +93,10 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
         %{
           "text" => "Pick a number between one and four",
           "answers" => [
-              %{"description" => "One", "value" => 1},
-              %{"description" => "Two", "value" => 2},
+              %{"description" => "Four", "value" => 4},
               %{"description" => "Three", "value" => 3},
-              %{"description" => "Four", "value" => 4}
+              %{"description" => "Two", "value" => 2},
+              %{"description" => "One", "value" => 1}
           ]
         }
       ],

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -35,9 +35,8 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
   end
 
   test "It can return the results from a survey for all groups", %{conn: conn} do
-    import IEx; IEx.pry()
     survey = Repo.one(Survey)
-    uri = "/api/v1/surveys#{survey.id}/averages"
+    uri = "/api/v1/surveys/#{survey.id}/averages"
 
     conn = get(conn, uri)
 
@@ -71,7 +70,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
     [question] = survey.questions
     group = Repo.one(Group) |> Repo.preload(:users)
     [user_1, user_2, user_3] = group.users
-    uri = "/api/v1/surveys#{survey.id}/averages/#{group.id}"
+    uri = "/api/v1/surveys/#{survey.id}/averages/#{group.id}"
 
     conn = get(conn, uri)
 

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -134,7 +134,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
     [question] = survey.questions
     group = Repo.one(Group) |> Repo.preload(:users)
     [user_1, user_2, user_3] = group.users
-    uri = "/api/v1/surveys/#{survey.id}/averages/#{group.id}"
+    uri = "/api/v1/surveys/#{survey.id}/user_averages"
 
     conn = get(conn, uri)
 

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -22,15 +22,18 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
     ]
     [answer_1, answer_2, answer_3, answer_4] = Enum.map(answer_list, fn answer -> Ecto.build_assoc(question, :answers, answer) |> Repo.insert!() end)
     [user_1, user_2, user_3] = users # User_1 : 3.5, User_2 : 3, User_3 : nil
-    response_1 = Ecto.build_assoc(answer_4, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    response_1 = Ecto.build_assoc(answer_4, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :recipient, user_1) |> Repo.update!()
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :reviewer, user_3) |> Repo.update!()
-    response_2 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :question, question) |> Repo.update!()
+    response_2 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :recipient, user_1) |> Repo.update!()
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :reviewer, user_2) |> Repo.update!()
-    response_3 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :question, question) |> Repo.update!()
+    response_3 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer, :question])
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :recipient, user_2) |> Repo.update!()
     Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :reviewer, user_1) |> Repo.update!()
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :question, question) |> Repo.update!()
     :ok
   end
 

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -4,7 +4,7 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
 
   setup do
     survey = %Survey{name: "Test Survey"} |> Repo.insert!() |> Repo.preload([:groups, :questions])
-    cohort = %Cohort{name: "1811"} |> Repo.insert!() |> Repo.preload(:users)
+    cohort = %Cohort{name: "1811", status: :Active} |> Repo.insert!() |> Repo.preload(:users)
     students = [
       %{name: "User 1", program: "B"},
       %{name: "User 2", program: "B"},

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -1,0 +1,141 @@
+defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
+  use FeedbackApiWeb.ConnCase
+  alias FeedbackApi.{Cohort, User, Survey, Question, Answer, Response, Repo}
+
+  setup do
+    survey = %Survey{name: "Test Survey"} |> Repo.insert!() |> Repo.preload([:groups, :questions])
+    cohort = %Cohort{name: "1811"} |> Repo.insert!() |> Repo.preload(:users)
+    students = [
+      %{name: "User 1", program: "B"},
+      %{name: "User 2", program: "B"},
+      %{name: "User 3", program: "B"}
+    ]
+    users = Enum.map(students, fn student -> Ecto.build_assoc(cohort, :users, student) |> Repo.preload([:ratings]) end)
+    group = Ecto.build_assoc(survey, :groups, %{name: "Test"}) |> Repo.insert!() |> Repo.preload([:users, :survey])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(group), :users, users) |> Repo.update!()
+    question = Ecto.build_assoc(survey, :questions, %{text: "Pick a number between one and four"}) |> Repo.insert! |> Repo.preload(:answers)
+    answer_list = [
+      %{description: "One", value: 1},
+      %{description: "Two", value: 2},
+      %{description: "Three", value: 3},
+      %{description: "Four", value: 4}
+    ]
+    [answer_1, answer_2, answer_3, answer_4] = Enum.map(answer_list, fn answer -> Ecto.build_assoc(question, :answers, answer) |> Repo.insert!() end)
+    [user_1, user_2, user_3] = users # User_1 : 3.5, User_2 : 3, User_3 : nil
+    response_1 = Ecto.build_assoc(answer_4, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :recipient, user_1) |> Repo.update!()
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :reviewer, user_3) |> Repo.update!()
+    response_2 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :recipient, user_1) |> Repo.update!()
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :reviewer, user_2) |> Repo.update!()
+    response_3 = Ecto.build_assoc(answer_3, :responses, %{}) |> Repo.insert!() |> Repo.preload([:reviewer, :recipient, :answer])
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :recipient, user_2) |> Repo.update!()
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :reviewer, user_1) |> Repo.update!()
+    :ok
+  end
+
+  test "It can return the results from a survey for all groups", %{conn: conn} do
+    import IEx; IEx.pry()
+    survey = Repo.one(Survey)
+    uri = "/api/v1/surveys#{survey.id}/averages"
+
+    conn = get(conn, uri)
+
+    expected = %{
+      "id" => survey.id,
+      "name" => survey.name,
+      "exp_date" => nil,
+      "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+      "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
+      "status" => "active",
+      "questions" => [
+        %{
+          "text" => "Pick a number between one and four",
+          "average_rating" => 3.25,
+          "answers" => [
+              %{"description" => "One", "value" => 1},
+              %{"description" => "Two", "value" => 2},
+              %{"description" => "Three", "value" => 3},
+              %{"description" => "Four", "value" => 4}
+          ]
+        }
+      ]
+    }
+
+    assert json_response(conn, 200) == expected
+
+  end
+
+  test "It can return the results from a survey for a group", %{conn: conn} do
+    survey = Repo.one(Survey) |> Repo.preload(:questions)
+    [question] = survey.questions
+    group = Repo.one(Group) |> Repo.preload([:users])
+    [user_1, user_2, user_3, user_4] = group.users
+    uri = "/api/v1/surveys#{survey.id}/averages/#{group.id}"
+
+    conn = get(conn, uri)
+
+    expected = %{
+      "id" => survey.id,
+      "name" => survey.name,
+      "exp_date" => nil,
+      "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+      "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
+      "status" => "active",
+      "questions" => [
+        %{
+          "text" => "Pick a number between one and four",
+          "answers" => [
+              %{"description" => "One", "value" => 1},
+              %{"description" => "Two", "value" => 2},
+              %{"description" => "Three", "value" => 3},
+              %{"description" => "Four", "value" => 4}
+          ]
+        }
+      ],
+      "groups" => [
+        %{
+          "id" => group.id,
+          "name" => "Test",
+          "members" => [
+            %{
+              "id" => user_1.id,
+              "name" => user_1.name,
+              "questions" => [
+                %{
+                  "id" => question.id,
+                  "text" => question.text,
+                  "average_rating" => 3.5
+                }
+              ]
+            },
+            %{
+              "id" => user_2.id,
+              "name" => user_2.name,
+              "questions" => [
+                %{
+                  "id" => question.id,
+                  "text" => question.text,
+                  "average_rating" => 3
+                }
+              ]
+            },
+            %{
+              "id" => user_3.id,
+              "name" => user_3.name,
+              "questions" => [
+                %{
+                  "id" => question.id,
+                  "text" => question.text,
+                  "average_rating" => nil
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    assert json_response(conn, 200) == expected
+  end
+end

--- a/test/feedback_api_web/controllers/survey_response_averages_test.exs
+++ b/test/feedback_api_web/controllers/survey_response_averages_test.exs
@@ -1,6 +1,6 @@
 defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
   use FeedbackApiWeb.ConnCase
-  alias FeedbackApi.{Cohort, User, Survey, Question, Answer, Response, Repo}
+  alias FeedbackApi.{Cohort, User, Group, Survey, Question, Answer, Response, Repo}
 
   setup do
     survey = %Survey{name: "Test Survey"} |> Repo.insert!() |> Repo.preload([:groups, :questions])
@@ -69,8 +69,8 @@ defmodule FeedbackApiWeb.SurveyResponseAveragesTest do
   test "It can return the results from a survey for a group", %{conn: conn} do
     survey = Repo.one(Survey) |> Repo.preload(:questions)
     [question] = survey.questions
-    group = Repo.one(Group) |> Repo.preload([:users])
-    [user_1, user_2, user_3, user_4] = group.users
+    group = Repo.one(Group) |> Repo.preload(:users)
+    [user_1, user_2, user_3] = group.users
     uri = "/api/v1/surveys#{survey.id}/averages/#{group.id}"
 
     conn = get(conn, uri)

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -56,6 +56,7 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
 
   test "Return all surveys", %{conn: conn} do
     survey = Repo.one(Survey)
+    question = Repo.one(Question)
     conn = get(conn, "/api/v1/surveys")
 
     expected = [
@@ -68,6 +69,7 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
         "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
         "questions" => [
           %{
+            "id" => question.id,
             "answers" => [%{"description" => "A thing", "value" => 3}],
             "text" => "What is this?"
           }

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -3,7 +3,7 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   alias FeedbackApi.{Cohort, Survey, Question, Repo}
 
   setup do
-    cohorts = [%{id: 1, name: "1811"}, %{id: 2, name: "1811"}]
+    cohorts = [%{id: 1, status: :Active, name: "1811"}, %{id: 2, status: :Active, name: "1811"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)
 
     [cohort_1, cohort_2] =

--- a/test/feedback_api_web/controllers/users_controller_test.exs
+++ b/test/feedback_api_web/controllers/users_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule FeedbackApiWeb.UsersControllerTest do
-  use FeedbackApiWeb.ConnCase
-  alias FeedbackApi.{Cohort, User}
+  # use FeedbackApiWeb.ConnCase
+  # alias FeedbackApi.{Cohort, User}
 
   # test "Create users", %{conn: conn} do
   #   conn = conn |> put_req_header("content-type", "application/json")


### PR DESCRIPTION
Adds survey response average endpoint at path `/api/v1/surveys/:id/averages`
Adds survey response for each user at path `/api/v1/surveys/:id/user_averages`
Adds documentation for average endpoints
Adds corrections for test suite

Temporarily removes user_id requirement for Survey creation pending auth implementation.

@aprildagonese @taylorsperry -- I had to adjust the formatting of the response from the specification in the endpoint due to my inability to insert the average information within the objects themselves. Would you mind taking a look at this and making sure this is okay? (Documentation is in README)