### PR TITLE
Student survey history

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Base url: https://turing-feedback-api.herokuapp.com
 
 [GET /api/v1/surveys/pending](#post-apiv1surveyspending)
 
+[GET /api/v1/surveys/history](#post-apiv1surveyshistory)
+
 [POST /api/v1/responses](#post-apiv1responses)
 
 ## For Routes Requiring Authorization:
@@ -612,6 +614,71 @@ Sample Response:
       }
     ],
     "status": "active"
+  }
+]
+```
+
+## GET /api/v1/surveys/history
+
+Purpose: To retrieve the completed and pending surveys to be completed for a user
+
+Params: `api_key={USER_API_KEY_HERE}`
+
+Sample Response:
+``` JSON
+[
+  {
+    "groups": [
+      {
+        "name": "Team1",
+        "members": [
+          {
+            "id": 8,
+            "name": "April Dagonese",
+            "cohort": "1811",
+            "program": "B",
+            "status": "Active"
+          },
+          {
+            "id": 9,
+            "name": "Scott Thomas",
+            "cohort": "1811",
+            "program": "B",
+            "status": "Active"
+          }
+        ]
+      }
+    ],
+    "surveyName": "Test Survey",
+    "id": 12,
+    "surveyExpiration": null,
+    "created_at": "2019-05-23T05:24:58",
+    "updated_at": "2019-05-23T05:24:58",
+    "questions": [
+      {
+        "options": [
+          {
+            "description": "Four",
+            "pointValue": 4
+          },
+          {
+            "description": "Three",
+            "pointValue": 3
+          },
+          {
+            "description": "Two",
+            "pointValue": 2
+          },
+          {
+            "description": "One",
+            "pointValue": 1
+          }
+        ],
+        "id": 42,
+        "questionTitle": "Pick a number between one and four"
+      }
+    ],
+    "status": "closed"
   }
 ]
 ```

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -69,10 +69,9 @@ defmodule FeedbackApi.Survey do
         where: members.id != ^user.id,
         where: survey.id not in ^Repo.all(
           from s in Survey,
-          join: g in assoc(s, :groups),
-          join: u in assoc(g, :users),
-          join: r in assoc(u, :responses),
-          where: u.id == ^user.id,
+          join: q in assoc(s, :questions),
+          join: r in assoc(q, :responses),
+          where: r.reviewer_id == ^user.id,
           select: s.id
         ),
         order_by: [asc: members.id, desc: answers.value, asc: survey.id],

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -58,6 +58,7 @@ defmodule FeedbackApi.Survey do
   end
 
   def pending_for_user(user) do
+    # Would like to do in one query using having, just trying to make sure it works for now
     Repo.all(
       from survey in Survey,
         join: groups in assoc(survey, :groups),

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -51,7 +51,7 @@ defmodule FeedbackApi.Survey do
         join: answers in assoc(questions, :answers),
         where: users.id == ^user.id,
         where: members.id != ^user.id,
-        order_by: [desc: survey.status, asc: survey.id],
+        order_by: [asc: members.id, desc: answers.value, desc: survey.status, asc: survey.id],
         preload: [groups: {groups, users: {members, cohort: cohort}},
         questions: {questions, answers: answers}]
     )

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -40,6 +40,23 @@ defmodule FeedbackApi.Survey do
     )
   end
 
+  def for_participant(user) do
+    Repo.all(
+      from survey in Survey,
+        join: groups in assoc(survey, :groups),
+        join: users in assoc(groups, :users),
+        join: members in assoc(groups, :users),
+        join: cohort in assoc(users, :cohort),
+        join: questions in assoc(survey, :questions),
+        join: answers in assoc(questions, :answers),
+        where: users.id == ^user.id,
+        where: members.id != ^user.id,
+        order_by: [desc: survey.status, asc: survey.id],
+        preload: [groups: {groups, users: {members, cohort: cohort}},
+        questions: {questions, answers: answers}]
+    )
+  end
+
   def one(id) do
     Repo.one(
       from survey in Survey,

--- a/lib/feedback_api_web/controllers/surveys/history_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/history_controller.ex
@@ -1,0 +1,10 @@
+defmodule FeedbackApiWeb.Surveys.HistoryController do
+  use FeedbackApiWeb, :controller
+
+  def index(conn, params) do
+    case User.authorize(params["api_key"]) do
+      nil -> conn |> put_status(:unauthorized) |> json(%{error: "Invalid API Key"})
+      user -> conn |> render("index.json", Survey.for_participant(user))
+    end
+  end
+end

--- a/lib/feedback_api_web/controllers/surveys/history_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/history_controller.ex
@@ -1,10 +1,11 @@
 defmodule FeedbackApiWeb.Surveys.HistoryController do
   use FeedbackApiWeb, :controller
+  alias FeedbackApi.{User, Survey}
 
   def index(conn, params) do
     case User.authorize(params["api_key"]) do
       nil -> conn |> put_status(:unauthorized) |> json(%{error: "Invalid API Key"})
-      user -> conn |> render("index.json", Survey.for_participant(user))
+      user -> conn |> render("index.json", %{surveys: Survey.for_participant(user)})
     end
   end
 end

--- a/lib/feedback_api_web/router.ex
+++ b/lib/feedback_api_web/router.ex
@@ -30,6 +30,7 @@ defmodule FeedbackApiWeb.Router do
 
     scope "/surveys", Surveys do
       get "/pending", PendingController, :index
+      get "/history", HistoryController, :index
     end
 
     post "/users/register", Users.RegisterController, :create

--- a/lib/feedback_api_web/views/surveys/history_view.ex
+++ b/lib/feedback_api_web/views/surveys/history_view.ex
@@ -1,0 +1,9 @@
+defmodule FeedbackApiWeb.Surveys.HistoryView do
+  use FeedbackApiWeb, :view
+  alias FeedbackApiWeb.SurveyView
+
+  def render("index.json", %{surveys: surveys}) do
+    render_many(surveys, SurveyView, "survey.json")
+  end
+
+end

--- a/test/feedback_api_web/controllers/student_survey_history_test.exs
+++ b/test/feedback_api_web/controllers/student_survey_history_test.exs
@@ -157,5 +157,7 @@ defmodule FeedbackApiWeb.StudentSurveyHistoryTest do
           ]
         }
       ]
+
+      assert json_response(conn, 200) == expected
   end
 end

--- a/test/feedback_api_web/controllers/student_survey_history_test.exs
+++ b/test/feedback_api_web/controllers/student_survey_history_test.exs
@@ -96,7 +96,7 @@ defmodule FeedbackApiWeb.StudentSurveyHistoryTest do
 
   test "Returns a 404 if API key is missing or invalid", %{conn: conn} do
     survey = Repo.one(Survey)
-    uri = "/api/v1/surveys/#{survey.id}/history?api_key=FakeApiKey"
+    uri = "/api/v1/surveys/history?api_key=FakeApiKey"
 
     conn = get(conn, uri)
 
@@ -110,7 +110,7 @@ defmodule FeedbackApiWeb.StudentSurveyHistoryTest do
     group = Repo.one(Group) |> Repo.preload(:users)
     [user_1, user_2, user_3] = group.users
 
-    uri = "/api/v1/surveys/#{survey.id}/history?api_key=#{user_2.api_key}"
+    uri = "/api/v1/surveys/history?api_key=#{user_2.api_key}"
 
     conn = get(conn, uri)
 

--- a/test/feedback_api_web/controllers/student_survey_history_test.exs
+++ b/test/feedback_api_web/controllers/student_survey_history_test.exs
@@ -1,0 +1,152 @@
+defmodule FeedbackApiWeb.StudentSurveyHistoryTest do
+  use FeedbackApiWeb.ConnCase
+  alias FeedbackApi.{Cohort, Group, Survey, Question, Answer, Repo}
+
+  setup do
+    cohort = %Cohort{name: "1811", status: :Active} |> Repo.insert!() |> Repo.preload(:users)
+
+    students = [
+      %{name: "User 1", program: "B", api_key: "user1"},
+      %{name: "User 2", program: "B", api_key: "user2"},
+      %{name: "User 3", program: "B", api_key: "user3"}
+    ]
+
+    users =
+      Enum.map(students, fn student ->
+        Ecto.build_assoc(cohort, :users, student)
+        |> Repo.insert!()
+        |> Repo.preload([:responses, :ratings])
+      end)
+
+    [user_1, user_2, user_3] = users
+
+    survey =
+      Ecto.build_assoc(user_3, :surveys, %Survey{name: "Test Survey"})
+      |> Repo.insert!()
+      |> Repo.preload([:groups, :questions])
+
+    group =
+      Ecto.build_assoc(survey, :groups, %{name: "Test"})
+      |> Repo.insert!()
+      |> Repo.preload([:users, :survey])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(group), :users, users) |> Repo.update!()
+
+    question =
+      Ecto.build_assoc(survey, :questions, %{text: "Pick a number between one and four"})
+      |> Repo.insert!()
+      |> Repo.preload(:answers)
+
+    answer_list = [
+      %{description: "One", value: 1},
+      %{description: "Two", value: 2},
+      %{description: "Three", value: 3},
+      %{description: "Four", value: 4}
+    ]
+
+    [_answer_1, _answer_2, answer_3, answer_4] =
+      Enum.map(answer_list, fn answer ->
+        Ecto.build_assoc(question, :answers, answer) |> Repo.insert!()
+      end)
+
+    response_1 =
+      Ecto.build_assoc(answer_4, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :recipient, user_1)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :reviewer, user_3)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_1), :question, question)
+    |> Repo.update!()
+
+    response_2 =
+      Ecto.build_assoc(answer_3, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :recipient, user_1)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :reviewer, user_2)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_2), :question, question)
+    |> Repo.update!()
+
+    response_3 =
+      Ecto.build_assoc(answer_3, :responses, %{})
+      |> Repo.insert!()
+      |> Repo.preload([:reviewer, :recipient, :answer, :question])
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :recipient, user_3)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :reviewer, user_2)
+    |> Repo.update!()
+
+    Ecto.Changeset.put_assoc(Ecto.Changeset.change(response_3), :question, question)
+    |> Repo.update!()
+
+    :ok
+  end
+
+  test "Returns all surveys for a student where they were a participant", %{conn: conn} do
+    survey = Repo.one(Survey)
+    question = Repo.one(Question)
+    [answer_1, answer_2, answer_3, answer_4] = Repo.all(Answer)
+    group = Repo.one(Group) |> Repo.preload(:users)
+    [user_1, user_2, user_3] = group.users
+
+    uri = "/api/v1/surveys/#{survey.id}/history?api_key=#{user_2.api_key}"
+
+    conn = get(conn, uri)
+
+    expected = [
+        %{
+          "id" => survey.id,
+          "surveyName" => survey.name,
+          "surveyExpiration" => nil,
+          "created_at" => NaiveDateTime.to_iso8601(survey.inserted_at),
+          "updated_at" => NaiveDateTime.to_iso8601(survey.updated_at),
+          "status" => "active",
+          "questions" => [
+            %{
+              "id" => question.id,
+              "questionTitle" => "Pick a number between one and four",
+              "options" => [
+                %{"description" => "Four", "pointValue" => 4, "id" => answer_4.id},
+                %{"description" => "Three", "pointValue" => 3, "id" => answer_3.id},
+                %{"description" => "Two", "pointValue" => 2, "id" => answer_2.id},
+                %{"description" => "One", "pointValue" => 1, "id" => answer_1.id}
+              ]
+            }
+          ],
+          "groups" => [
+            %{
+              "members" => [
+                %{
+                  "id" => user_1.id,
+                  "name" => user_1.name,
+                  "cohort" => "1811",
+                  "program" => "B",
+                  "status" => "Active"
+                },
+                %{
+                  "id" => user_3.id,
+                  "name" => user_3.name,
+                  "cohort" => "1811",
+                  "program" => "B",
+                  "status" => "Active"
+                }
+              ],
+              "name" => "Test"
+            }
+          ]
+        }
+      ]
+  end
+end

--- a/test/feedback_api_web/controllers/student_survey_history_test.exs
+++ b/test/feedback_api_web/controllers/student_survey_history_test.exs
@@ -94,6 +94,15 @@ defmodule FeedbackApiWeb.StudentSurveyHistoryTest do
     :ok
   end
 
+  test "Returns a 404 if API key is missing or invalid", %{conn: conn} do
+    survey = Repo.one(Survey)
+    uri = "/api/v1/surveys/#{survey.id}/history?api_key=FakeApiKey"
+
+    conn = get(conn, uri)
+
+    assert json_response(conn, 401) == %{"error" => "Invalid API Key"}
+  end
+
   test "Returns all surveys for a student where they were a participant", %{conn: conn} do
     survey = Repo.one(Survey)
     question = Repo.one(Question)

--- a/test/feedback_api_web/controllers/users_controller_test.exs
+++ b/test/feedback_api_web/controllers/users_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule FeedbackApiWeb.UsersControllerTest do
   use FeedbackApiWeb.ConnCase
   alias FeedbackApi.{Cohort, User, Repo}
-  import Ecto.Query
 
   setup do
     cohort_1811 =


### PR DESCRIPTION
Adds student survey history endpoint to show all completed and existing surveys for a user.
Adds correction for pending survey logic.
Adds testing for history endpoint and to ensure logic is sound on pending endpoint.
Adds documentation for history endpoint.