### PR TITLE
Survey index ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,13 @@ Params: None
 Sample Response:
 ``` JSON
 {
+  "averages": [
+    {
+      "question_id": 42,
+      "questionTitle": "Pick a number between one and four",
+      "average_rating": 3.3333333333333333
+    }
+  ],
   "survey": {
     "id": 1,
     "surveyName": "Test survey",
@@ -355,34 +362,27 @@ Sample Response:
       {
         "name": "Team1",
         "members": [{
-          "id": 7,
-          "name": "Peter Lapicola",
-          "cohort": "1811",
-          "program": "B",
-          "status": "Active"
-        },
-        {
-          "id": 8,
-          "name": "April Dagonese",
-          "cohort": "1811",
-          "program": "B",
-          "status": "Active"
-        },
-        {
-          "id": 9,
-          "name": "Scott Thomas",
-          "cohort": "1811",
-          "program": "B",
-          "status": "Active"
-        }
-      ],
-    }
-  ],
-    "averages": [
-      {
-        "question_id": 42,
-        "questionTitle": "Pick a number between one and four",
-        "average_rating": 3.3333333333333333
+            "id": 7,
+            "name": "Peter Lapicola",
+            "cohort": "1811",
+            "program": "B",
+            "status": "Active"
+          },
+          {
+            "id": 8,
+            "name": "April Dagonese",
+            "cohort": "1811",
+            "program": "B",
+            "status": "Active"
+          },
+          {
+            "id": 9,
+            "name": "Scott Thomas",
+            "cohort": "1811",
+            "program": "B",
+            "status": "Active"
+          }
+        ],
       }
     ]
   }

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -32,7 +32,7 @@ defmodule FeedbackApi.Survey do
         left_join: questions in assoc(survey, :questions),
         left_join: answers in assoc(questions, :answers),
         where: survey.user_id == ^user.id,
-        order_by: [desc: survey.inserted_at, desc: answers.value],
+        order_by: [asc: survey.status, desc: survey.inserted_at, desc: answers.value],
         preload: [
           groups: {groups, users: {users, cohort: cohort}},
           questions: {questions, answers: answers}


### PR DESCRIPTION
Updates survey index to put open surveys prior to closed surveys, regardless of creation date, then subsort by existing filters.

Updates README for survey averages endpoint to more clearly designate the averages block position in the JSON.