### PR TITLE
Update survey averages to ensure response is successful

### DIFF
--- a/lib/feedback_api_web/controllers/surveys/average_controller.ex
+++ b/lib/feedback_api_web/controllers/surveys/average_controller.ex
@@ -3,8 +3,10 @@ defmodule FeedbackApiWeb.Surveys.AverageController do
   alias FeedbackApi.Survey
 
   def show(conn, params) do
-    average = Survey.averages(params["survey_id"])
+    averages = Survey.averages(params["survey_id"])
+    survey = Survey.one(params["survey_id"])
+    response = %{averages: averages, survey: survey}
 
-    render(conn, "show.json", %{average: average})
+    render(conn, "show.json", %{average: response})
   end
 end


### PR DESCRIPTION
Updates survey averages query to address situation where join was resulting in multiple surveys causing Repo.one to raise an error.