### PR TITLE
Multiple survey owners update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ feedback_api-*.tar
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+.elixir_ls

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -32,7 +32,8 @@ defmodule FeedbackApi.Survey do
         left_join: cohort in assoc(users, :cohort),
         left_join: questions in assoc(survey, :questions),
         left_join: answers in assoc(questions, :answers),
-        where: survey.user_id == ^user.id,
+        left_join: owners in assoc(survey, :owners),
+        where: owners.id == ^user.id,
         order_by: [asc: survey.status, desc: survey.inserted_at, desc: answers.value],
         preload: [
           groups: {groups, users: {users, cohort: cohort}},

--- a/lib/feedback_api/survey.ex
+++ b/lib/feedback_api/survey.ex
@@ -12,6 +12,7 @@ defmodule FeedbackApi.Survey do
     belongs_to :user, User
     has_many :groups, Group
     has_many :questions, Question
+    many_to_many :owners, FeedbackApi.User, join_through: FeedbackApi.SurveyOwner
 
     timestamps()
   end

--- a/lib/feedback_api/survey_owner.ex
+++ b/lib/feedback_api/survey_owner.ex
@@ -1,0 +1,18 @@
+defmodule FeedbackApi.SurveyOwner do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "survey_owners" do
+    belongs_to :survey, FeedbackApi.Survey
+    belongs_to :user, FeedbackApi.User
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(survey_owner, attrs) do
+    survey_owner
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/lib/feedback_api/user.ex
+++ b/lib/feedback_api/user.ex
@@ -17,8 +17,9 @@ defmodule FeedbackApi.User do
     belongs_to :cohort, FeedbackApi.Cohort
     has_many :responses, FeedbackApi.Response, foreign_key: :reviewer_id
     has_many :ratings, FeedbackApi.Response, foreign_key: :recipient_id
-    has_many :surveys, FeedbackApi.Survey
+    # has_many :surveys, FeedbackApi.Survey
     many_to_many :groups, FeedbackApi.Group, join_through: FeedbackApi.GroupMember
+    many_to_many :surveys, FeedbackApi.User, join_through: FeedbackApi.SurveyOwner
 
     timestamps()
   end

--- a/lib/feedback_api/user.ex
+++ b/lib/feedback_api/user.ex
@@ -17,9 +17,8 @@ defmodule FeedbackApi.User do
     belongs_to :cohort, FeedbackApi.Cohort
     has_many :responses, FeedbackApi.Response, foreign_key: :reviewer_id
     has_many :ratings, FeedbackApi.Response, foreign_key: :recipient_id
-    # has_many :surveys, FeedbackApi.Survey
     many_to_many :groups, FeedbackApi.Group, join_through: FeedbackApi.GroupMember
-    many_to_many :surveys, FeedbackApi.User, join_through: FeedbackApi.SurveyOwner
+    many_to_many :surveys, FeedbackApi.Survey, join_through: FeedbackApi.SurveyOwner
 
     timestamps()
   end

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -6,12 +6,23 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
     Repo.transaction(fn ->
       try do
         survey =
-          Ecto.build_assoc(user, :surveys, %Survey{
+          # Ecto.build_assoc(user, :surveys, %Survey{
+          #   name: arguments["surveyName"],
+          #   status: parse_status(arguments["status"]),
+          #   exp_date: parseDateTime(arguments["surveyExpiration"])
+          # })
+          # |> Repo.insert!()
+
+          %Survey{
             name: arguments["surveyName"],
             status: parse_status(arguments["status"]),
             exp_date: parseDateTime(arguments["surveyExpiration"])
-          })
+          }
           |> Repo.insert!()
+          |> Repo.preload(:owners)
+          |> Ecto.Changeset.change()
+          |> Ecto.Changeset.put_assoc(:owners, [user])
+          |> Repo.update!()
 
         create_groups(survey, arguments["groups"])
         create_questions(survey, arguments["questions"])

--- a/lib/feedback_api_web/facades/survey_create_facade.ex
+++ b/lib/feedback_api_web/facades/survey_create_facade.ex
@@ -6,13 +6,6 @@ defmodule FeedbackApiWeb.SurveyCreateFacade do
     Repo.transaction(fn ->
       try do
         survey =
-          # Ecto.build_assoc(user, :surveys, %Survey{
-          #   name: arguments["surveyName"],
-          #   status: parse_status(arguments["status"]),
-          #   exp_date: parseDateTime(arguments["surveyExpiration"])
-          # })
-          # |> Repo.insert!()
-
           %Survey{
             name: arguments["surveyName"],
             status: parse_status(arguments["status"]),

--- a/priv/repo/migrations/20190622202639_create_survey_owners.exs
+++ b/priv/repo/migrations/20190622202639_create_survey_owners.exs
@@ -1,0 +1,15 @@
+defmodule FeedbackApi.Repo.Migrations.CreateSurveyOwners do
+  use Ecto.Migration
+
+  def change do
+    create table(:survey_owners) do
+      add :survey_id, references(:surveys, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps()
+    end
+
+    create index(:survey_owners, [:survey_id])
+    create index(:survey_owners, [:user_id])
+  end
+end

--- a/priv/repo/multiple_owner_translation.exs
+++ b/priv/repo/multiple_owner_translation.exs
@@ -1,0 +1,11 @@
+alias FeedbackApi.{Repo, Survey, User}
+import Ecto.Query
+
+Repo.all(from survey in Survey,
+   left_join: owners in assoc(survey, :owners),
+   where: is_nil(owners.id),
+   preload: [:user, :owners])
+   |> Enum.each(fn survey -> Ecto.Changeset.change(survey) 
+      |> Ecto.Changeset.put_assoc(:owners, [survey.user]) 
+      |> Repo.update!() 
+      end)

--- a/test/feedback_api_web/controllers/surveys_controller_test.exs
+++ b/test/feedback_api_web/controllers/surveys_controller_test.exs
@@ -5,11 +5,17 @@ defmodule FeedbackApiWeb.SurveysControllerTest do
   setup do
     %User{api_key: "wxyz897", role: :Instructor} |> Repo.insert!()
 
-    survey =
+    mikedaowl = 
       %User{api_key: "mikedaowl", role: :Instructor}
       |> Repo.insert!()
-      |> Ecto.build_assoc(:surveys, %{name: "A test survey"})
+
+    survey =
+      %Survey{name: "A test survey"}
       |> Repo.insert!()
+      |> Repo.preload(:owners)
+      |> Ecto.Changeset.change
+      |> Ecto.Changeset.put_assoc(:owners, [mikedaowl])
+      |> Repo.update!()
 
     cohorts = [%{id: 1, status: :Active, name: "1811"}, %{id: 2, status: :Active, name: "1811"}]
     cohort_changesets = Enum.map(cohorts, fn cohort -> Cohort.changeset(%Cohort{}, cohort) end)


### PR DESCRIPTION
Adds migration to allow for future multiple owner functionality on survey
Adds script to update any surveys created prior to multi owner functionality to use new owner functionality
Updates survey creation and lookup logic to use new owner functionality
Updates testing to create surveys using new owner functionality